### PR TITLE
feat: improve tables

### DIFF
--- a/TODO.mkd
+++ b/TODO.mkd
@@ -9,9 +9,9 @@
 - [X] Queries with multiple statements
 - [X] Return statement SQL with `results`
 - [X] Add Celery to docker-compose
+- [X] Representations should have columns
 - [/] Compute the schema of downstream nodes
 - [ ] Write columns back to YAML
-- [ ] Representations should have columns
 - [ ] Organize files (`api/`, `models/`, etc)
 - [ ] Paginating results
 - [ ] Limit results

--- a/examples/configs/nodes/core/comments.yaml
+++ b/examples/configs/nodes/core/comments.yaml
@@ -1,5 +1,5 @@
 description: A fact table with comments
-representations:
+tables:
   gsheets:
     catalog: null
     schema: null

--- a/examples/configs/nodes/core/users.yaml
+++ b/examples/configs/nodes/core/users.yaml
@@ -1,5 +1,5 @@
 description: A user dimension table
-representations:
+tables:
   gsheets:
     catalog: null
     schema: null

--- a/src/datajunction/utils.py
+++ b/src/datajunction/utils.py
@@ -7,7 +7,7 @@ import os
 from functools import lru_cache
 from io import StringIO
 from pathlib import Path
-from typing import Any, Dict, Iterator, Set
+from typing import Any, Dict, Iterator, Optional, Set
 
 import asciidag.graph
 import asciidag.node
@@ -155,3 +155,38 @@ def get_name_from_path(repository: Path, path: Path) -> str:
     )
 
     return encoded
+
+
+def get_more_specific_type(current_type: Optional[str], new_type: str) -> str:
+    """
+    Given two types, return the most specific one.
+
+    Different databases might store the same column as different types. For example, Hive
+    might store timestamps as strings, while Postgres would store the same data as a
+    datetime.
+
+        >>> get_more_specific_type('str',  'datetime')
+        'datetime'
+        >>> get_more_specific_type('str',  'int')
+        'int'
+
+    """
+    if current_type is None:
+        return new_type
+
+    hierarchy = [
+        "bytes",
+        "str",
+        "float",
+        "int",
+        "Decimal",
+        "bool",
+        "datetime",
+        "date",
+        "time",
+        "timedelta",
+        "list",
+        "dict",
+    ]
+
+    return sorted([current_type, new_type], key=hierarchy.index)[1]

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -6,7 +6,7 @@ Tests for ``datajunction.models``.
 
 from sqlmodel import Session
 
-from datajunction.models import Node
+from datajunction.models import Column, Database, Node, Table
 
 
 def test_node_relationship(session: Session) -> None:
@@ -26,3 +26,34 @@ def test_node_relationship(session: Session) -> None:
     assert node_a.parents == []
     assert node_b.parents == []
     assert node_c.parents == [node_a, node_b]
+
+
+def test_node_columns(session: Session) -> None:
+    """
+    Test that the node schema is derived from its tables.
+    """
+    database = Database(name="test", URI="sqlite://")
+
+    table_a = Table(
+        database_id=database.id,
+        table="A",
+        columns=[
+            Column(name="ds", type="str"),
+            Column(name="user_id", type="int"),
+        ],
+    )
+
+    table_b = Table(
+        database_id=database.id,
+        table="B",
+        columns=[Column(name="ds", type="datetime")],
+    )
+
+    node = Node(name="C", tables=[table_a, table_b])
+
+    session.add(node)
+
+    assert node.columns == [
+        Column(name="ds", type="datetime"),
+        Column(name="user_id", type="int"),
+    ]

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -9,6 +9,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from datajunction.utils import (
+    get_more_specific_type,
     get_name_from_path,
     get_session,
     get_settings,
@@ -107,3 +108,12 @@ def test_get_name_from_path() -> None:
         )
         == "5%25_nodes.test"
     )
+
+
+def test_get_more_specific_type() -> None:
+    """
+    Test ``get_more_specific_type``.
+    """
+    assert get_more_specific_type("str", "datetime") == "datetime"
+    assert get_more_specific_type("str", "int") == "int"
+    assert get_more_specific_type(None, "int") == "int"


### PR DESCRIPTION
This PR renames "representation" to "table" everywhere, and also move columns to they belong to tables, not nodes. Instead, nodes now have a property called `columns` that derive the columns based on the associated tables.