### PR TITLE
feat: compute SQL for node

### DIFF
--- a/TODO.mkd
+++ b/TODO.mkd
@@ -13,12 +13,14 @@
 - [X] Paginating results
 - [X] Compute the schema of downstream nodes
 - [X] Organize files (`api/`, `models/`, etc)
+- [ ] Split models tests
+- [ ] Make database/node name unique
 - [ ] Translate metrics into SQL
 - [ ] Compute metrics (ie, run query)
 - [ ] Allow only 1 aggregation (metric)
 - [ ] Add an enum for types, instead of using strings (also, a type for a parse tree)
 - [ ] Limit results
-- [ ] Write columns back to YAML
+- [ ] Write columns back to YAML -> way to add column metadata (dimension and more)
 - [ ] Optimize data transfer (delta-of-delta for timeseries, msgpack?)
 - [ ] Compute statistics on columns (histogram, correlation)
 - [ ] Move data on JOINs based on column statistics
@@ -27,6 +29,13 @@
 - [ ] 2 modes of join: Shillelagh and move data
 - [ ] Auto-map dimensions from the DB schema?
 - [ ] UUID for models?
+- [ ] Name/description for the server in `.env`
+
+Integration with Superset:
+
+1. Run `superset sync dj http://dj.example.com/`
+2. Creates database, a `metrics` datasets, and add metrics as custom SQL (metric `foo` with SQL `foo`)
+3. Depending on the metric selected in Explore bring in dimensions (AirBnB has that?)
 
 Node types:
 
@@ -56,10 +65,12 @@ SQL input:
 
 ```
 SELECT core.likes FROM metrics
+WHERE user.country = 'BR'
 ```
 
 Gets translated to:
 
 ```
 SELECT COUNT(*) FROM content_actions
+JOIN dim_users ON content_actions.user_id = dim_users.id
 ```

--- a/TODO.mkd
+++ b/TODO.mkd
@@ -13,9 +13,10 @@
 - [X] Paginating results
 - [X] Compute the schema of downstream nodes
 - [X] Organize files (`api/`, `models/`, etc)
+- [ ] Translate metrics into SQL
+- [ ] Rename `queries.py` to `engine.py`
 - [ ] Split models tests
 - [ ] Make database/node name unique
-- [ ] Translate metrics into SQL
 - [ ] Compute metrics (ie, run query)
 - [ ] Allow only 1 aggregation (metric)
 - [ ] Add an enum for types, instead of using strings (also, a type for a parse tree)

--- a/src/datajunction/models/database.py
+++ b/src/datajunction/models/database.py
@@ -24,6 +24,7 @@ class Database(SQLModel, table=True):  # type: ignore
         URI: druid://localhost:8082/druid/v2/sql/
         read-only: true
         async_: false
+        cost: 1.0
 
     """
 
@@ -33,6 +34,7 @@ class Database(SQLModel, table=True):  # type: ignore
     URI: str
     read_only: bool = True
     async_: bool = Field(default=False, sa_column_kwargs={"name": "async"})
+    cost: float = 1.0
 
     created_at: datetime = Field(default_factory=partial(datetime.now, timezone.utc))
     updated_at: datetime = Field(default_factory=partial(datetime.now, timezone.utc))
@@ -46,6 +48,9 @@ class Database(SQLModel, table=True):  # type: ignore
         back_populates="database",
         sa_relationship_kwargs={"cascade": "all, delete"},
     )
+
+    def __hash__(self):
+        return hash(self.id)
 
 
 class Table(SQLModel, table=True):  # type: ignore

--- a/src/datajunction/sql/dag.py
+++ b/src/datajunction/sql/dag.py
@@ -62,9 +62,9 @@ def get_computable_databases(node: Node) -> Set[Database]:
     # add all the databases where the node is explicitly materialized
     databases = {table.database for table in node.tables}
 
-    # add all the databases that are shared between the parents
-    parent_dbs = [get_computable_databases(parent) for parent in node.parents]
-    if parent_dbs:
-        databases |= set.intersection(*parent_dbs)
+    # add all the databases that are common between the parents
+    if node.parents:
+        parent_databases = [get_computable_databases(parent) for parent in node.parents]
+        databases |= set.intersection(*parent_databases)
 
     return databases

--- a/src/datajunction/sql/transpile.py
+++ b/src/datajunction/sql/transpile.py
@@ -1,0 +1,98 @@
+"""
+Functions for transpiling SQL.
+
+These functions parse the DJ SQL used to define node expressions, and generate SQLAlchemy
+queries which can be then executed in specific databases.
+"""
+
+from operator import attrgetter
+from typing import Any, List, Optional
+
+from sqlalchemy.engine import create_engine
+from sqlalchemy.schema import MetaData, Table
+from sqlalchemy.sql import Select, func, select
+from sqloxide import parse_sql
+
+from datajunction.models.node import Node
+from datajunction.sql.parse import find_nodes_by_key
+
+
+def get_query_for_node(node: Node) -> Select:
+    """
+    Build a SQLAlchemy ``select()`` for a given node.
+    """
+    # if the node is materialized we use the table with the cheapest cost
+    if node.tables:
+        table = sorted(node.tables, key=attrgetter("cost"))[0]
+        engine = create_engine(table.database.URI)
+        materialized_table = Table(
+            table.table,
+            MetaData(bind=engine),
+            schema=table.schema_,
+            autoload=True,
+        )
+        return select(materialized_table)
+
+    tree = parse_sql(node.expression, dialect="ansi")
+
+    projection = get_projection(node, tree)
+    source = get_source(node, tree)
+    return projection.select_from(source)
+
+
+def get_projection(node: Node, tree: Any) -> Select:
+    """
+    Build the ``SELECT`` part of a query.
+    """
+    expressions = []
+    projection = next(find_nodes_by_key(tree, "projection"))
+    for expression in projection:
+        alias: Optional[str] = None
+        if "UnnamedExpr" in expression:
+            expression = expression["UnnamedExpr"]
+        elif "ExprWithAlias" in expression:
+            alias = expression["ExprWithAlias"]["alias"]["value"]
+            expression = expression["ExprWithAlias"]["expr"]
+        else:
+            raise NotImplementedError(f"Unable to handle expression: {expression}")
+
+        expressions.append(get_expression(node.parents, expression, alias))
+
+    return select(expressions)
+
+
+def get_expression(
+    parents: List[Node],
+    expression: Any,
+    alias: Optional[str] = None,
+) -> Any:
+    """
+    Build an expression.
+    """
+    if "Function" in expression:
+        return get_function(parents, expression["Function"], alias)
+    if expression == "Wildcard":
+        return "*"
+    raise NotImplementedError(f"Unable to handle expression: {expression}")
+
+
+def get_function(
+    parents: List[Node],
+    expression: Any,
+    alias: Optional[str] = None,
+) -> Any:
+    """
+    Build a function.
+    """
+    name = expression["name"][0]["value"]
+    args = expression["args"]
+    evaluated_args = [get_expression(parents, arg["Unnamed"]) for arg in args]
+    return getattr(func, name.lower())(*evaluated_args).label(alias)
+
+
+def get_source(node: Node, tree: Any) -> Select:  # pylint: disable=unused-argument
+    """
+    Build the ``FROM`` part of a query.
+    """
+    # For now assume no JOINs or multiple relations
+    return get_query_for_node(node.parents[0]).alias(node.parents[0].name)

--- a/tests/cli/compile_test.py
+++ b/tests/cli/compile_test.py
@@ -23,6 +23,7 @@ from datajunction.cli.compile import (
     run,
 )
 from datajunction.models.database import Column, Database
+from datajunction.models.query import Query  # pylint: disable=unused-import
 
 
 @pytest.mark.asyncio
@@ -55,6 +56,7 @@ async def test_index_databases(repository: Path, session: Session) -> None:
     assert sorted(configs, key=itemgetter("name")) == [
         {
             "async_": False,
+            "cost": 1.0,
             "created_at": datetime(2021, 1, 2, 0, 0, tzinfo=timezone.utc),
             "updated_at": datetime(2021, 1, 2, 0, 0, tzinfo=timezone.utc),
             "name": "druid",
@@ -64,6 +66,7 @@ async def test_index_databases(repository: Path, session: Session) -> None:
         },
         {
             "async_": False,
+            "cost": 1.0,
             "created_at": datetime(2021, 1, 2, 0, 0, tzinfo=timezone.utc),
             "updated_at": datetime(2021, 1, 2, 0, 0, tzinfo=timezone.utc),
             "name": "gsheets",
@@ -73,6 +76,7 @@ async def test_index_databases(repository: Path, session: Session) -> None:
         },
         {
             "async_": False,
+            "cost": 1.0,
             "created_at": datetime(2021, 1, 2, 0, 0, tzinfo=timezone.utc),
             "updated_at": datetime(2021, 1, 2, 0, 0, tzinfo=timezone.utc),
             "name": "postgres",

--- a/tests/sql/dag_test.py
+++ b/tests/sql/dag_test.py
@@ -1,0 +1,46 @@
+"""
+Tests for ``datajunction.sql.dag``.
+"""
+
+from datajunction.models.database import Database, Table
+from datajunction.models.node import Node
+from datajunction.models.query import Query  # pylint: disable=unused-import
+from datajunction.sql.dag import get_computable_databases
+
+
+def test_get_computable_databases() -> None:
+    """
+    Test ``get_computable_databases``.
+    """
+    database_1 = Database(id=1, name="shared", URI="sqlite://", cost=1.0)
+    database_2 = Database(id=2, name="not shared", URI="sqlite://", cost=2.0)
+    database_3 = Database(id=3, name="fast", URI="sqlite://", cost=0.1)
+
+    parent_a = Node(
+        name="A",
+        tables=[
+            Table(database=database_1, table="A"),
+            Table(database=database_2, table="A"),
+        ],
+    )
+    parent_b = Node(
+        name="B",
+        tables=[Table(database=database_1, table="B")],
+    )
+    child = Node(
+        name="C",
+        tables=[Table(database=database_3, table="C")],
+        parents=[parent_a, parent_b],
+    )
+
+    assert {database.name for database in get_computable_databases(child)} == {
+        "fast",
+        "shared",
+    }
+    assert {database.name for database in get_computable_databases(parent_a)} == {
+        "shared",
+        "not shared",
+    }
+    assert {database.name for database in get_computable_databases(parent_b)} == {
+        "shared",
+    }

--- a/tests/sql/dag_test.py
+++ b/tests/sql/dag_test.py
@@ -23,10 +23,12 @@ def test_get_computable_databases() -> None:
             Table(database=database_2, table="A"),
         ],
     )
+
     parent_b = Node(
         name="B",
         tables=[Table(database=database_1, table="B")],
     )
+
     child = Node(
         name="C",
         tables=[Table(database=database_3, table="C")],

--- a/tests/sql/transpile_test.py
+++ b/tests/sql/transpile_test.py
@@ -1,0 +1,97 @@
+"""
+Tests for ``datajunction.sql.transpile``.
+"""
+
+from pytest_mock import MockerFixture
+from sqlalchemy.engine import create_engine
+
+from datajunction.models.database import Column, Database, Table
+from datajunction.models.node import Node
+from datajunction.models.query import Query  # pylint: disable=unused-import
+from datajunction.sql.transpile import get_query_for_node
+
+
+def test_get_query_for_node_materialized(mocker: MockerFixture) -> None:
+    """
+    Test ``get_query_for_node`` when the node is materialized.
+    """
+    database_1 = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
+
+    parent = Node(name="A")
+
+    child = Node(
+        name="B",
+        tables=[
+            Table(
+                database=database_1,
+                table="B",
+                columns=[Column(name="one", type="str")],
+            ),
+        ],
+        expression="SELECT COUNT(*) AS cnt FROM A",
+        parents=[parent],
+    )
+
+    engine = create_engine(database_1.URI)
+    connection = engine.connect()
+    connection.execute("CREATE TABLE B (cnt INTEGER)")
+    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+
+    assert str(get_query_for_node(child)) == 'SELECT "B".cnt \nFROM "B"'
+
+
+def test_get_query_for_node_not_materialized(mocker: MockerFixture) -> None:
+    """
+    Test ``get_query_for_node`` when the node is not materialized.
+    """
+    database_1 = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
+    database_2 = Database(id=2, name="fast", URI="sqlite://", cost=0.1)
+
+    parent = Node(
+        name="A",
+        tables=[
+            Table(
+                database=database_1,
+                table="A",
+                columns=[
+                    Column(name="one", type="str"),
+                    Column(name="two", type="str"),
+                ],
+            ),
+            Table(
+                database=database_2,
+                table="A",
+                columns=[Column(name="one", type="str")],
+            ),
+        ],
+    )
+
+    engine = create_engine(database_1.URI)
+    connection = engine.connect()
+    connection.execute("CREATE TABLE A (one TEXT, two TEXT)")
+    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+
+    child = Node(
+        name="B",
+        expression="SELECT COUNT(*) AS cnt FROM A",
+        parents=[parent],
+    )
+
+    space = " "
+
+    assert (
+        str(get_query_for_node(child))
+        == f'''SELECT count(?) AS cnt{space}
+FROM (SELECT "A".one AS one, "A".two AS two{space}
+FROM "A") AS "A"'''
+    )
+
+    # unnamed expression
+    child.expression = "SELECT COUNT(*) FROM A"
+
+    assert (
+        str(get_query_for_node(child))
+        == f'''SELECT count(?) AS count_1{space}
+FROM (SELECT "A".one AS one, "A".two AS two{space}
+FROM "A") AS "A"'''
+    )


### PR DESCRIPTION
This PR adds some basic transpilation — parsing the SQL expression of a node using `sqloxide.parse_sql`, and building a SQLAlchemy `Select` statement out of it.