### PR TITLE
feat: groupbys in the metrics API

### DIFF
--- a/TODO.mkd
+++ b/TODO.mkd
@@ -22,7 +22,9 @@
 - [X] Translate metrics into SQL
 - [X] Metrics API
 - [X] Allow only 1 aggregation (metric)
-- [ ] Allow filtering/grouping in metrics API
+- [X] Allow grouping in metrics API
+- [ ] Allow filtering in metrics API
+- [ ] Handle columns with database-specific names (`__timestamp` in Druid, eg)
 - [ ] Allow metrics to be queried via SQL
 - [ ] Limit results
 - [ ] Write columns back to YAML -> way to add column metadata (dimension and more)

--- a/examples/configs/databases/druid.yaml
+++ b/examples/configs/databases/druid.yaml
@@ -1,3 +1,4 @@
 description: An Apache Druid database
 URI: druid://host.docker.internal:8082/druid/v2/sql/
 read_only: true
+cost: 1

--- a/examples/configs/databases/gsheets.yaml
+++ b/examples/configs/databases/gsheets.yaml
@@ -1,3 +1,4 @@
 description: A Google Sheets connector
 URI: gsheets://
 read_only: true
+cost: 100

--- a/examples/configs/databases/postgres.yaml
+++ b/examples/configs/databases/postgres.yaml
@@ -1,3 +1,4 @@
 description: A Postgres database
 URI: postgresql://username:FoolishPassword@host.docker.internal:5433/examples
 read_only: false
+cost: 10

--- a/examples/docker/druid_spec.json
+++ b/examples/docker/druid_spec.json
@@ -32,6 +32,8 @@
       },
       "dimensionsSpec": {
         "dimensions": [
+	  "id",
+	  "user_id",
           "text"
         ]
       },
@@ -39,16 +41,6 @@
         {
           "name": "count",
           "type": "count"
-        },
-        {
-          "name": "sum_id",
-          "type": "longSum",
-          "fieldName": "id"
-        },
-        {
-          "name": "sum_user_id",
-          "type": "longSum",
-          "fieldName": "user_id"
         }
       ]
     }

--- a/tests/api/metrics_test.py
+++ b/tests/api/metrics_test.py
@@ -35,7 +35,9 @@ def test_read_metrics(session: Session, client: TestClient) -> None:
 
 
 def test_read_metrics_data(
-    mocker: MockerFixture, session: Session, client: TestClient,
+    mocker: MockerFixture,
+    session: Session,
+    client: TestClient,
 ) -> None:
     """
     Test ``GET /metrics/{node_id}/data/``.

--- a/tests/cli/compile_test.py
+++ b/tests/cli/compile_test.py
@@ -67,7 +67,7 @@ async def test_index_databases(repository: Path, session: Session) -> None:
         },
         {
             "async_": False,
-            "cost": 1.0,
+            "cost": 100.0,
             "created_at": datetime(2021, 1, 2, 0, 0, tzinfo=timezone.utc),
             "updated_at": datetime(2021, 1, 2, 0, 0, tzinfo=timezone.utc),
             "name": "gsheets",
@@ -77,7 +77,7 @@ async def test_index_databases(repository: Path, session: Session) -> None:
         },
         {
             "async_": False,
-            "cost": 1.0,
+            "cost": 10.0,
             "created_at": datetime(2021, 1, 2, 0, 0, tzinfo=timezone.utc),
             "updated_at": datetime(2021, 1, 2, 0, 0, tzinfo=timezone.utc),
             "name": "postgres",


### PR DESCRIPTION
Allow groupbys in the metrics API:

```bash
% curl http://localhost:8000/metrics/ | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   311  100   311    0     0   3839      0 --:--:-- --:--:-- --:--:--  3839
[
  {
    "id": 3,
    "name": "core.num_comments",
    "description": "Number of comments",
    "created_at": "2022-01-17T19:06:09.215689",
    "updated_at": "2022-01-17T19:06:09.215701",
    "expression": "SELECT COUNT(*) FROM core.comments",
    "dimensions": [
      "core.comments/id",
      "core.comments/user_id",
      "core.comments/timestamp",
      "core.comments/text"
    ]
  }
]
% curl "http://localhost:8000/metrics/3/data/?d=core.comments/user_id" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1554  100  1554    0     0   4557      0 --:--:-- --:--:-- --:--:--  4557
{
  "database_id": 7,
  "catalog": null,
  "schema_": null,
  "id": "0f2ca7f9-5701-4a44-8a6c-9117a18db00d",
  "submitted_query": "SELECT count('*') AS \"count_1\" \nFROM (SELECT \"druid\".\"comments\".\"__time\" AS \"__time\", \"druid\".\"comments\".\"count\" AS \"count\", \"druid\".\"comments\".\"id\" AS \"id\", \"druid\".\"comments\".\"text\" AS \"text\", \"druid\".\"comments\".\"user_id\" AS \"user_id\" \nFROM \"druid\".\"comments\") AS \"core.comments\" GROUP BY \"core.comments\".\"user_id\"",
  "executed_query": "SELECT count('*') AS \"count_1\" \nFROM (SELECT \"druid\".\"comments\".\"__time\" AS \"__time\", \"druid\".\"comments\".\"count\" AS \"count\", \"druid\".\"comments\".\"id\" AS \"id\", \"druid\".\"comments\".\"text\" AS \"text\", \"druid\".\"comments\".\"user_id\" AS \"user_id\" \nFROM \"druid\".\"comments\") AS \"core.comments\" GROUP BY \"core.comments\".\"user_id\"",
  "scheduled": "2022-04-03T01:40:09.113939",
  "started": "2022-04-03T01:40:09.113998",
  "finished": "2022-04-03T01:40:09.169528",
  "state": "FINISHED",
  "progress": 1,
  "results": [
    {
      "sql": "SELECT count('*') AS \"count_1\" \nFROM (SELECT \"druid\".\"comments\".\"__time\" AS \"__time\", \"druid\".\"comments\".\"count\" AS \"count\", \"druid\".\"comments\".\"id\" AS \"id\", \"druid\".\"comments\".\"text\" AS \"text\", \"druid\".\"comments\".\"user_id\" AS \"user_id\" \nFROM \"druid\".\"comments\") AS \"core.comments\" GROUP BY \"core.comments\".\"user_id\"",
      "columns": [
        {
          "name": "count_1",
          "type": "UNKNOWN"
        }
      ],
      "rows": [
        [
          1
        ],
        [
          2
        ],
        [
          3
        ],
        [
          4
        ],
        [
          5
        ],
        [
          6
        ]
      ],
      "row_count": 6
    }
  ],
  "next": null,
  "previous": null,
  "errors": []
}
```