### PR TITLE
feat: filters in the metric API

### DIFF
--- a/TODO.mkd
+++ b/TODO.mkd
@@ -23,7 +23,7 @@
 - [X] Metrics API
 - [X] Allow only 1 aggregation (metric)
 - [X] Allow grouping in metrics API
-- [ ] Allow filtering in metrics API
+- [X] Allow filtering in metrics API
 - [ ] Handle columns with database-specific names (`__timestamp` in Druid, eg)
 - [ ] Allow metrics to be queried via SQL
 - [ ] Limit results


### PR DESCRIPTION
Allow filters in the metric API, eg:

```bash
% curl "http://localhost:8000/metrics/3/data/?d=core.comments/user_id&f=core.comments/user_id=-1" | jq
```