### PR TITLE
feat: aliases in DQL

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,7 +89,7 @@ repos:
   hooks:
   - id: pylint
     name: pylint
-    entry: pylint --disable=fixme
+    entry: pylint --disable=fixme,duplicate-code,use-implicit-booleaness-not-comparison
     language: system
     types: [python]
     exclude: ^templates/

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,8 +1,14 @@
 [MESSAGES CONTROL]
 disable =
   duplicate-code
+  use-implicit-booleaness-not-comparison
+  fixme
 
 [MASTER]
 # https://github.com/samuelcolvin/pydantic/issues/1961#issuecomment-759522422
 extension-pkg-whitelist=pydantic
 ignore=templates,docs
+disable=
+  duplicate-code
+  use-implicit-booleaness-not-comparison
+  fixme

--- a/src/datajunction/__init__.py
+++ b/src/datajunction/__init__.py
@@ -1,7 +1,6 @@
 """
 Package version and name.
 """
-# pylint: disable=fixme
 
 from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
 

--- a/src/datajunction/sql/transpile.py
+++ b/src/datajunction/sql/transpile.py
@@ -5,7 +5,7 @@ These functions parse the DJ SQL used to define node expressions, and generate S
 queries which can be then executed in specific databases.
 """
 
-# pylint: disable=unused-argument
+# pylint: disable=unused-argument, fixme
 
 import operator
 from typing import Any, List, Optional, Union, cast


### PR DESCRIPTION
Allow aliases in DQL (DJ query language):

```sql
SELECT B AS my_metric FROM metrics
```