### PR TITLE
feat: heterogeneous tables

### DIFF
--- a/src/datajunction/cli/compile.py
+++ b/src/datajunction/cli/compile.py
@@ -132,7 +132,7 @@ async def index_nodes(  # pylint: disable=too-many-locals
 
     We first compute the schema of source nodes, since they are simply fetched from the
     database using SQLAlchemy. After that we compute the schema of downstream nodes, as
-    the schema of source nodes become available.
+    the schemas of source nodes become available.
     """
     directory = repository / "nodes"
 

--- a/src/datajunction/engine.py
+++ b/src/datajunction/engine.py
@@ -1,6 +1,8 @@
 """
 Query related functions.
 """
+# pylint: disable=fixme
+
 import ast
 import operator
 import re
@@ -171,7 +173,7 @@ def get_query_for_sql(sql: str) -> QueryCreate:
         raise Exception(f"Unable to compute {node.name} (no common database)")
     database = sorted(databases, key=operator.attrgetter("cost"))[0]
 
-    query = get_query(tree, node.parents, database)
+    query = get_query(node, tree, database)
     engine = sqla_create_engine(database.URI)
     sql = str(query.compile(engine, compile_kwargs={"literal_binds": True}))
 

--- a/src/datajunction/sql/dag.py
+++ b/src/datajunction/sql/dag.py
@@ -79,10 +79,10 @@ def get_computable_databases(
     databases = {table.database for table in tables}
 
     # add all the databases that are common between the parents and match all the columns
-    referenced_columns = get_referenced_columns(node.expression, node.parents)
+    parent_columns = get_referenced_columns(node.expression, node.parents)
     if node.parents:
         parent_databases = [
-            get_computable_databases(parent, referenced_columns[parent.name])
+            get_computable_databases(parent, parent_columns[parent.name])
             for parent in node.parents
         ]
         databases |= set.intersection(*parent_databases)

--- a/tests/sql/dag_test.py
+++ b/tests/sql/dag_test.py
@@ -2,10 +2,12 @@
 Tests for ``datajunction.sql.dag``.
 """
 
-from datajunction.models.database import Database, Table
+import pytest
+
+from datajunction.models.database import Column, Database, Table
 from datajunction.models.node import Node
-from datajunction.models.query import Query  # pylint: disable=unused-import
-from datajunction.sql.dag import get_computable_databases
+from datajunction.sql.dag import get_computable_databases, get_referenced_columns
+from datajunction.typing import ColumnType
 
 
 def test_get_computable_databases() -> None:
@@ -46,3 +48,128 @@ def test_get_computable_databases() -> None:
     assert {database.name for database in get_computable_databases(parent_b)} == {
         "shared",
     }
+
+
+def test_get_computable_databases_heterogeneous_columns() -> None:
+    """
+    Test ``get_computable_databases`` when columns are heterogeneous.
+    """
+    database_1 = Database(id=1, name="one", URI="sqlite://", cost=1.0)
+    database_2 = Database(id=2, name="two", URI="sqlite://", cost=2.0)
+
+    parent = Node(
+        name="core.A",
+        tables=[
+            Table(
+                database=database_1,
+                table="A",
+                columns=[
+                    Column(name="ds", type=ColumnType.STR),
+                    Column(name="user_id", type=ColumnType.INT),
+                ],
+            ),
+            Table(
+                database=database_2,
+                table="A",
+                columns=[
+                    Column(name="ds", type=ColumnType.STR),
+                ],
+            ),
+        ],
+    )
+
+    child_1 = Node(
+        name="core.B",
+        expression="SELECT COUNT(core.A.user_id) FROM core.A",
+        parents=[parent],
+    )
+
+    assert {database.name for database in get_computable_databases(child_1)} == {
+        "one",
+    }
+
+    child_2 = Node(
+        name="core.C",
+        expression="SELECT COUNT(user_id) FROM core.A",
+        parents=[parent],
+    )
+
+    assert {database.name for database in get_computable_databases(child_2)} == {
+        "one",
+    }
+
+
+def test_get_referenced_columns() -> None:
+    """
+    Test ``get_referenced_columns``.
+    """
+    database = Database(id=1, name="one", URI="sqlite://", cost=1.0)
+
+    parent_1 = Node(
+        name="core.A",
+        tables=[
+            Table(
+                database=database,
+                table="A",
+                columns=[
+                    Column(name="ds", type=ColumnType.STR),
+                    Column(name="user_id", type=ColumnType.INT),
+                ],
+            ),
+        ],
+    )
+    parent_2 = Node(
+        name="core.B",
+        tables=[
+            Table(
+                database=database,
+                table="B",
+                columns=[
+                    Column(name="ds", type=ColumnType.STR),
+                    Column(name="event_id", type=ColumnType.INT),
+                ],
+            ),
+        ],
+    )
+
+    assert get_referenced_columns("SELECT core.A.ds FROM core.A", [parent_1]) == {
+        "core.A": {"ds"}
+    }
+    assert get_referenced_columns("SELECT ds FROM core.A", [parent_1]) == {
+        "core.A": {"ds"}
+    }
+    assert get_referenced_columns(
+        "SELECT ds FROM core.A WHERE user_id > 0", [parent_1]
+    ) == {"core.A": {"ds", "user_id"}}
+    assert (
+        get_referenced_columns(
+            (
+                "SELECT core.A.ds, core.A.user_id, core.B.event_id "
+                "FROM core.A JOIN core.B ON core.A.ds = core.B.ds"
+            ),
+            [parent_1, parent_2],
+        )
+        == {"core.A": {"ds", "user_id"}, "core.B": {"ds", "event_id"}}
+    )
+    assert (
+        get_referenced_columns(
+            (
+                "SELECT user_id, event_id "
+                "FROM core.A JOIN core.B ON core.A.ds = core.B.ds"
+            ),
+            [parent_1, parent_2],
+        )
+        == {"core.A": {"ds", "user_id"}, "core.B": {"ds", "event_id"}}
+    )
+    with pytest.raises(Exception) as excinfo:
+        get_referenced_columns(
+            (
+                "SELECT ds, user_id, event_id "
+                "FROM core.A JOIN core.B ON core.A.ds = core.B.ds"
+            ),
+            [parent_1, parent_2],
+        )
+    assert str(excinfo.value) == "Column ds is ambiguous"
+    with pytest.raises(Exception) as excinfo:
+        get_referenced_columns("SELECT invalid FROM core.A", [parent_1])
+    assert str(excinfo.value) == "Column invalid not found in any parent"

--- a/tests/sql/dag_test.py
+++ b/tests/sql/dag_test.py
@@ -133,14 +133,18 @@ def test_get_referenced_columns() -> None:
     )
 
     assert get_referenced_columns("SELECT core.A.ds FROM core.A", [parent_1]) == {
-        "core.A": {"ds"}
+        "core.A": {"ds"},
     }
     assert get_referenced_columns("SELECT ds FROM core.A", [parent_1]) == {
-        "core.A": {"ds"}
+        "core.A": {"ds"},
     }
-    assert get_referenced_columns(
-        "SELECT ds FROM core.A WHERE user_id > 0", [parent_1]
-    ) == {"core.A": {"ds", "user_id"}}
+    assert (
+        get_referenced_columns(
+            "SELECT ds FROM core.A WHERE user_id > 0",
+            [parent_1],
+        )
+        == {"core.A": {"ds", "user_id"}}
+    )
     assert (
         get_referenced_columns(
             (


### PR DESCRIPTION
This PR allows the use of heterogeneous tables, ie, tables with different sets of columns. The `get_computable_databases` function has been updated to take into consideration the node expression when determining the databases in which it can be computed, as well as the `get_select_for_node` function.