### PR TITLE
feat: API for getting SQL of a metric

### DIFF
--- a/src/datajunction/api/metrics.py
+++ b/src/datajunction/api/metrics.py
@@ -3,7 +3,7 @@ Metric related APIs.
 """
 
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Response
 from sqlmodel import Session, SQLModel, select
@@ -34,6 +34,15 @@ class Metric(SQLModel):
     expression: str
 
     dimensions: List[str]
+
+
+class TranslatedSQL(SQLModel):
+    """
+    Class for SQL generated from a given metric.
+    """
+
+    database_id: int
+    sql: str
 
 
 @router.get("/metrics/", response_model=List[Metric])
@@ -71,6 +80,18 @@ def read_metric(node_id: int, *, session: Session = Depends(get_session)) -> Met
     )
 
 
+def get_metric(session: Session, node_id: int) -> Node:
+    """
+    Return a metric node given a node ID.
+    """
+    node = session.get(Node, node_id)
+    if not node:
+        raise HTTPException(status_code=404, detail="Metric node not found")
+    if not node.expression or not is_metric(node.expression):
+        raise HTTPException(status_code=400, detail="Not a metric node")
+    return node
+
+
 @router.get("/metrics/{node_id}/data/", response_model=QueryWithResults)
 def read_metrics_data(
     node_id: int,
@@ -85,12 +106,7 @@ def read_metrics_data(
     """
     Return data for a metric.
     """
-    node = session.get(Node, node_id)
-    if not node:
-        raise HTTPException(status_code=404, detail="Metric node not found")
-    if not node.expression or not is_metric(node.expression):
-        raise HTTPException(status_code=400, detail="Not a metric node")
-
+    node = get_metric(session, node_id)
     create_query = get_query_for_node(node, d, f)
 
     return save_query_and_run(
@@ -99,4 +115,28 @@ def read_metrics_data(
         settings,
         response,
         background_tasks,
+    )
+
+
+@router.get("/metrics/{node_id}/sql/", response_model=TranslatedSQL)
+def read_metrics_sql(
+    node_id: int,
+    database_id: Optional[int] = None,
+    d: List[str] = Query([]),  # pylint: disable=invalid-name
+    f: List[str] = Query([]),  # pylint: disable=invalid-name
+    *,
+    session: Session = Depends(get_session),
+) -> TranslatedSQL:
+    """
+    Return SQL for a metric.
+
+    A database can be optionally specified. If no database is specified the optimal one
+    will be used.
+    """
+    node = get_metric(session, node_id)
+    create_query = get_query_for_node(node, d, f, database_id)
+
+    return TranslatedSQL(
+        database_id=create_query.database_id,
+        sql=create_query.submitted_query,
     )

--- a/src/datajunction/engine.py
+++ b/src/datajunction/engine.py
@@ -89,6 +89,7 @@ def get_query_for_node(
     node: Node,
     groupbys: List[str],
     filters: List[str],
+    database_id: Optional[int] = None,
 ) -> QueryCreate:
     """
     Return a DJ QueryCreate object from a given node.
@@ -96,7 +97,14 @@ def get_query_for_node(
     databases = get_computable_databases(node)
     if not databases:
         raise Exception(f"Unable to compute {node.name} (no common database)")
-    database = sorted(databases, key=operator.attrgetter("cost"))[0]
+    if database_id:
+        for database in databases:
+            if database.id == database_id:
+                break
+        else:
+            raise Exception(f"Unable to compute {node.name} on database {database_id}")
+    else:
+        database = sorted(databases, key=operator.attrgetter("cost"))[0]
 
     engine = sqla_create_engine(database.URI)
     node_select = get_select_for_node(node, database)


### PR DESCRIPTION
Add a new endpoint to fetch the SQL for a given metric:

```
% curl "http://localhost:8000/metrics/6/" | jq
{
  "id": 6,
  "name": "core.num_comments",
  "description": "Number of comments",
  "created_at": "2022-01-17T19:06:09.215689",
  "updated_at": "2022-04-04T16:27:53.374001",
  "expression": "SELECT COUNT(*) FROM core.comments",
  "dimensions": [
    "core.comments.id",
    "core.comments.user_id",
    "core.comments.timestamp",
    "core.comments.text"
  ]
}

% curl "http://localhost:8000/metrics/6/sql/?d=core.comments.user_id" | jq
{
  "database_id": 7,
  "sql": "SELECT count('*') AS \"count_1\" \nFROM (SELECT \"druid\".\"comments\".\"__time\" AS \"__time\", \"druid\".\"comments\".\"count\" AS \"count\", \"druid\".\"comments\".\"id\" AS \"id\", \"druid\".\"comments\".\"text\" AS \"text\", \"druid\".\"comments\".\"user_id\" AS \"user_id\" \nFROM \"druid\".\"comments\") AS \"core.comments\" GROUP BY \"core.comments\".\"user_id\""
}
```