### PR TITLE
feat: reloader for dj compile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,15 @@ services:
       - dj
     command: celery -A datajunction.api.queries.celery worker --loglevel=info
 
+  watchdog:
+    container_name: watchdog
+    build: .
+    volumes:
+      - .:/code
+    depends_on:
+      - dj
+    command: dj compile --reload
+
   redis:
     image: redis:latest
     container_name: query_broker

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,11 +57,12 @@ install_requires =
     python-dotenv==0.19.2
     SQLAlchemy-Utils==0.38.2
     cachelib==0.5.0
+    asciidag==0.2.0
     celery>=5.2.3
     redis>=4.1.0
-    sqlparse==0.4.2
-    asciidag==0.2.0
     sqloxide==0.1.13
+    sqlparse==0.4.2
+    watchfiles==0.12
 
 [options.packages.find]
 where = src
@@ -75,16 +76,16 @@ exclude =
 
 # Add here test requirements (semicolon/line-separated)
 testing =
-    setuptools>=49.6.0
-    pytest>=6.2.5
+    codespell>=2.1.0
+    freezegun>=1.1.0
+    pre-commit>=2.15.0
+    pyfakefs>=4.5.1
+    pylint>=2.11.1
+    pytest-asyncio==0.15.1
     pytest-cov>=2.12.1
     pytest-mock>=3.6.1
-    pyfakefs>=4.5.1
-    pre-commit>=2.15.0
-    freezegun>=1.1.0
-    pytest-asyncio==0.15.1
-    codespell>=2.1.0
-    pylint>=2.11.1
+    pytest>=6.2.5
+    setuptools>=49.6.0
     pip-tools>=6.4.0
 docs =
     sphinx>=4.1.2

--- a/src/datajunction/console.py
+++ b/src/datajunction/console.py
@@ -2,13 +2,14 @@
 DataJunction (DJ) is a metric repository.
 
 Usage:
-    dj compile [REPOSITORY] [--loglevel=INFO]
+    dj compile [REPOSITORY] [--loglevel=INFO] [--reload]
 
 Actions:
     compile                 Compile repository
 
 Options:
     --loglevel=LEVEL        Level for logging. [default: INFO]
+    --reload                Watch for changes. [default: false]
 
 Released under the MIT license.
 (c) 2018 Beto Dealmeida <roberto@dealmeida.net>
@@ -43,7 +44,7 @@ async def main() -> None:
 
     try:
         if arguments["compile"]:
-            await compile_.run(repository)
+            await compile_.run(repository, arguments["--reload"])
     except asyncio.CancelledError:
         _logger.info("Canceled")
 

--- a/tests/console_test.py
+++ b/tests/console_test.py
@@ -24,6 +24,7 @@ async def test_main_compile(mocker: MockerFixture) -> None:
         "datajunction.console.docopt",
         return_value={
             "--loglevel": "debug",
+            "--reload": False,
             "compile": True,
             "REPOSITORY": None,
         },
@@ -37,7 +38,7 @@ async def test_main_compile(mocker: MockerFixture) -> None:
     )
 
     await console.main()
-    compile_.run.assert_called_with(Path("/path/to/repository"))
+    compile_.run.assert_called_with(Path("/path/to/repository"), False)
 
 
 @pytest.mark.asyncio
@@ -52,13 +53,14 @@ async def test_main_compile_passing_repository(mocker: MockerFixture) -> None:
         "datajunction.console.docopt",
         return_value={
             "--loglevel": "debug",
+            "--reload": False,
             "compile": True,
             "REPOSITORY": "/path/to/another/repository",
         },
     )
 
     await console.main()
-    compile_.run.assert_called_with(Path("/path/to/another/repository"))
+    compile_.run.assert_called_with(Path("/path/to/another/repository"), False)
 
 
 @pytest.mark.asyncio
@@ -74,6 +76,7 @@ async def test_main_canceled(mocker: MockerFixture) -> None:
         "datajunction.console.docopt",
         return_value={
             "--loglevel": "debug",
+            "--reload": False,
             "compile": True,
             "REPOSITORY": "/path/to/another/repository",
         },


### PR DESCRIPTION
Allow running `dj compile --reload`. Also updated `docker-compose.yml` to run a watchdog.

With this changes to nodes are automatically compiled.

Closes https://github.com/DataJunction/datajunction/issues/44.