### PR TITLE
feat: consider expression when choosing a DB in `get_query_for_sql`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,9 +74,9 @@ Now, if we want to compute the metric in our Hive warehouse we can build a pipel
 
 .. code-block:: bash
 
-    % curl "http://localhost:8000/metrics/2/sql/?database=1"
+    % curl "http://localhost:8000/metrics/2/sql/?database_id=1"
     {
-      "database_id": 9,
+      "database_id": 1,
       "sql": "SELECT count('*') AS count_1 \nFROM (SELECT default.fact_comments.id AS id, default.fact_comments.user_id AS user_id, default.fact_comments.timestamp AS timestamp, default.fact_comments.text AS text \nFROM default.fact_comments) AS \"comments\""
     }
 
@@ -104,13 +104,13 @@ For example, if we want to group the metric by the user_id, to see how many comm
 
 .. code-block:: bash
 
-    % curl "http://localhost:8000/metrics/2/sql/?database=1&d=comments.user_id&f=comments.user_id>0"
+    % curl "http://localhost:8000/metrics/2/sql/?database_id=1&d=comments.user_id&f=comments.user_id>0"
 
 If instead we want the actual data, instead of the SQL:
 
 .. code-block:: bash
 
-    % curl "http://localhost:8000/metrics/2/data/?database=1&d=comments.user_id&f=comments.user_id>0"
+    % curl "http://localhost:8000/metrics/2/data/?database_id=1&d=comments.user_id&f=comments.user_id>0"
 
 And if we omit the ``database_id`` DJ will compute the data using the fastest database (ie, the one with lowest ``costt``). It's also possible to specify tales with different costs:
 

--- a/src/datajunction/sql/transpile.py
+++ b/src/datajunction/sql/transpile.py
@@ -21,7 +21,7 @@ from sqloxide import parse_sql
 
 from datajunction.models.database import Database
 from datajunction.models.node import Node
-from datajunction.sql.dag import get_referenced_columns
+from datajunction.sql.dag import get_referenced_columns_from_sql
 from datajunction.sql.functions import function_registry
 from datajunction.sql.parse import find_nodes_by_key
 from datajunction.typing import (
@@ -294,7 +294,7 @@ def get_source(
     Build the ``FROM`` part of a query.
     """
     # For now assume no JOINs or multiple relations
-    parent_columns = get_referenced_columns(expression, parents)
+    parent_columns = get_referenced_columns_from_sql(expression, parents)
     parent = parents[0]
     return get_select_for_node(parent, database, parent_columns[parent.name]).alias(
         parent.name,


### PR DESCRIPTION
When choosing a DB to run arbitrary SQL against a metric we were not taking the referenced columns in consideration, only the cost of each database.

Closes https://github.com/DataJunction/datajunction/issues/69.