### PR TITLE
feat: API for SQL against metrics

### DIFF
--- a/src/datajunction/api/databases.py
+++ b/src/datajunction/api/databases.py
@@ -5,19 +5,40 @@ Database related APIs.
 import logging
 from typing import List
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
+from sqlalchemy.engine.url import URL
 from sqlmodel import Session, select
 
 from datajunction.models.database import Database
-from datajunction.utils import get_session
+from datajunction.utils import DJ_DATABASE_ID, get_session
 
 _logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
 @router.get("/databases/", response_model=List[Database])
-def read_databases(*, session: Session = Depends(get_session)) -> List[Database]:
+def read_databases(
+    *, request: Request, session: Session = Depends(get_session)
+) -> List[Database]:
     """
     List the available databases.
     """
-    return session.exec(select(Database)).all()
+    native_database = Database(
+        id=DJ_DATABASE_ID,
+        name="dj",
+        description="Native DJ",
+        URI=str(
+            URL(
+                "dj",
+                host=request.url.hostname,
+                port=request.url.port,
+                database=str(DJ_DATABASE_ID),
+            ),
+        ),
+        read_only=True,
+    )
+
+    databases = session.exec(select(Database)).all()
+    databases.append(native_database)
+
+    return databases

--- a/src/datajunction/api/main.py
+++ b/src/datajunction/api/main.py
@@ -11,15 +11,25 @@ import logging
 
 from fastapi import FastAPI
 
+from datajunction import __version__
 from datajunction.api import databases, metrics, queries
 from datajunction.models.database import Column, Database, Table
 from datajunction.models.node import Node
 from datajunction.models.query import Query
-from datajunction.utils import create_db_and_tables
+from datajunction.utils import create_db_and_tables, get_settings
 
 _logger = logging.getLogger(__name__)
 
-app = FastAPI()
+settings = get_settings()
+app = FastAPI(
+    title=settings.name,
+    description=settings.description,
+    version=__version__,
+    license_info={
+        "name": "MIT License",
+        "url": "https://mit-license.org/",
+    },
+)
 app.include_router(databases.router)
 app.include_router(queries.router)
 app.include_router(metrics.router)

--- a/src/datajunction/api/queries.py
+++ b/src/datajunction/api/queries.py
@@ -19,7 +19,7 @@ from fastapi import (
 from sqlmodel import Session
 
 from datajunction.config import Settings
-from datajunction.engine import process_query
+from datajunction.engine import get_query_for_sql, process_query
 from datajunction.models.query import (
     Query,
     QueryCreate,
@@ -27,7 +27,7 @@ from datajunction.models.query import (
     QueryState,
     QueryWithResults,
 )
-from datajunction.utils import get_session, get_settings
+from datajunction.utils import DJ_DATABASE_ID, get_session, get_settings
 
 _logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -50,6 +50,9 @@ def submit_query(
     """
     Run or schedule a query.
     """
+    if create_query.database_id == DJ_DATABASE_ID:
+        create_query = get_query_for_sql(create_query.submitted_query)
+
     return save_query_and_run(
         create_query,
         session,

--- a/src/datajunction/engine.py
+++ b/src/datajunction/engine.py
@@ -215,11 +215,14 @@ def get_new_projection_and_from(
         else:
             raise NotImplementedError(f"Unable to handle expression: {expression}")
 
-        if "Identifier" not in expression:
+        if "Identifier" in expression:
+            name = expression["Identifier"]["value"]
+        elif "CompoundIdentifier" in expression:
+            name = ".".join(part["value"] for part in expression["CompoundIdentifier"])
+        else:
             new_projection.append(projection_expression)
             continue
 
-        name = expression["Identifier"]["value"]
         if alias is None:
             alias = {
                 "quote_style": '"',

--- a/src/datajunction/utils.py
+++ b/src/datajunction/utils.py
@@ -16,6 +16,8 @@ from sqlmodel import Session, SQLModel, create_engine
 from datajunction.config import Settings
 from datajunction.typing import ColumnType
 
+DJ_DATABASE_ID = 0
+
 
 def setup_logging(loglevel: str) -> None:
     """

--- a/tests/api/databases_test.py
+++ b/tests/api/databases_test.py
@@ -26,8 +26,14 @@ def test_read_databases(session: Session, client: TestClient) -> None:
     data = response.json()
 
     assert response.status_code == 200
-    assert len(data) == 1
+    assert len(data) == 2
+
     assert data[0]["name"] == "gsheets"
     assert data[0]["URI"] == "gsheets://"
     assert data[0]["description"] == "A Google Sheets connector"
     assert data[0]["read_only"] is True
+
+    assert data[1]["name"] == "dj"
+    assert data[1]["URI"] == "dj://testserver/0"
+    assert data[1]["description"] == "Native DJ"
+    assert data[1]["read_only"] is True


### PR DESCRIPTION
API for running queries against metrics:

```bash
% curl -H "Content-Type: application/json" \
> -d '{"database_id":0,"submitted_query":"SELECT core.num_comments FROM metrics"}' \
> http://localhost:8000/queries/ | jq
{
  "database_id": 37,
  "catalog": null,
  "schema_": null,
  "id": "4232b850-c651-44fd-b5fa-879f53ef9666",
  "submitted_query": "SELECT count('*') AS \"core.num_comments\" \nFROM (SELECT \"druid\".\"comments\".\"__time\" AS \"__time\", \"druid\".\"comments\".\"count\" AS \"count\", \"druid\".\"comments\".\"id\" AS \"id\", \"druid\".\"comments\".\"text\" AS \"text\", \"druid\".\"comments\".\"user_id\" AS \"user_id\" \nFROM \"druid\".\"comments\") AS \"core.comments\"",
  "executed_query": "SELECT count('*') AS \"core.num_comments\" \nFROM (SELECT \"druid\".\"comments\".\"__time\" AS \"__time\", \"druid\".\"comments\".\"count\" AS \"count\", \"druid\".\"comments\".\"id\" AS \"id\", \"druid\".\"comments\".\"text\" AS \"text\", \"druid\".\"comments\".\"user_id\" AS \"user_id\" \nFROM \"druid\".\"comments\") AS \"core.comments\"",
  "scheduled": "2022-04-08T01:21:43.143060",
  "started": "2022-04-08T01:21:43.143146",
  "finished": "2022-04-08T01:21:43.717735",
  "state": "FINISHED",
  "progress": 1,
  "results": [
    {
      "sql": "SELECT count('*') AS \"core.num_comments\" \nFROM (SELECT \"druid\".\"comments\".\"__time\" AS \"__time\", \"druid\".\"comments\".\"count\" AS \"count\", \"druid\".\"comments\".\"id\" AS \"id\", \"druid\".\"comments\".\"text\" AS \"text\", \"druid\".\"comments\".\"user_id\" AS \"user_id\" \nFROM \"druid\".\"comments\") AS \"core.comments\"",
      "columns": [
        {
          "name": "core.num_comments",
          "type": "UNKNOWN"
        }
      ],
      "rows": [
        [
          21
        ]
      ],
      "row_count": 1
    }
  ],
  "next": null,
  "previous": null,
  "errors": []
}
```

Closes https://github.com/DataJunction/datajunction/issues/60.