### PR TITLE
feat: DJ and SQLite builtin databases

### DIFF
--- a/src/datajunction/api/databases.py
+++ b/src/datajunction/api/databases.py
@@ -5,40 +5,19 @@ Database related APIs.
 import logging
 from typing import List
 
-from fastapi import APIRouter, Depends, Request
-from sqlalchemy.engine.url import URL
+from fastapi import APIRouter, Depends
 from sqlmodel import Session, select
 
 from datajunction.models.database import Database
-from datajunction.utils import DJ_DATABASE_ID, get_session
+from datajunction.utils import get_session
 
 _logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
 @router.get("/databases/", response_model=List[Database])
-def read_databases(
-    *, request: Request, session: Session = Depends(get_session)
-) -> List[Database]:
+def read_databases(*, session: Session = Depends(get_session)) -> List[Database]:
     """
     List the available databases.
     """
-    native_database = Database(
-        id=DJ_DATABASE_ID,
-        name="dj",
-        description="Native DJ",
-        URI=str(
-            URL(
-                "dj",
-                host=request.url.hostname,
-                port=request.url.port,
-                database=str(DJ_DATABASE_ID),
-            ),
-        ),
-        read_only=True,
-    )
-
-    databases = session.exec(select(Database)).all()
-    databases.append(native_database)
-
-    return databases
+    return session.exec(select(Database)).all()

--- a/src/datajunction/api/queries.py
+++ b/src/datajunction/api/queries.py
@@ -19,6 +19,7 @@ from fastapi import (
 from sqlmodel import Session
 
 from datajunction.config import Settings
+from datajunction.constants import DJ_DATABASE_ID
 from datajunction.engine import get_query_for_sql, process_query
 from datajunction.models.query import (
     Query,
@@ -27,7 +28,7 @@ from datajunction.models.query import (
     QueryState,
     QueryWithResults,
 )
-from datajunction.utils import DJ_DATABASE_ID, get_session, get_settings
+from datajunction.utils import get_session, get_settings
 
 _logger = logging.getLogger(__name__)
 router = APIRouter()

--- a/src/datajunction/config.py
+++ b/src/datajunction/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):  # pylint: disable=too-few-public-methods
 
     name: str = "DJ server"
     description: str = "A DataJunction metrics repository"
+    url: str = "http://localhost:8000/"
 
     # SQLAlchemy URI for the metadata database.
     index: str = "sqlite:///dj.db"

--- a/src/datajunction/constants.py
+++ b/src/datajunction/constants.py
@@ -1,0 +1,6 @@
+"""
+Useful constants.
+"""
+
+DJ_DATABASE_ID = 0
+SQLITE_DATABASE_ID = 1

--- a/src/datajunction/engine.py
+++ b/src/datajunction/engine.py
@@ -17,6 +17,7 @@ from sqlmodel import Session, create_engine, select
 from sqloxide import parse_sql
 
 from datajunction.config import Settings
+from datajunction.constants import DJ_DATABASE_ID
 from datajunction.models.database import Database
 from datajunction.models.node import Node
 from datajunction.models.query import (
@@ -188,7 +189,9 @@ def get_database_for_sql(tree: ParseTree, parents: List[Node]) -> Database:
         )
     else:
         session = next(get_session())
-        databases = session.exec(select(Database)).all()
+        databases = session.exec(
+            select(Database).where(Database.id != DJ_DATABASE_ID),
+        ).all()
 
     if not databases:
         raise Exception("Unable to run SQL (no common database)")

--- a/src/datajunction/utils.py
+++ b/src/datajunction/utils.py
@@ -16,8 +16,6 @@ from sqlmodel import Session, SQLModel, create_engine
 from datajunction.config import Settings
 from datajunction.typing import ColumnType
 
-DJ_DATABASE_ID = 0
-
 
 def setup_logging(loglevel: str) -> None:
     """

--- a/tests/api/databases_test.py
+++ b/tests/api/databases_test.py
@@ -26,14 +26,9 @@ def test_read_databases(session: Session, client: TestClient) -> None:
     data = response.json()
 
     assert response.status_code == 200
-    assert len(data) == 2
+    assert len(data) == 1
 
     assert data[0]["name"] == "gsheets"
     assert data[0]["URI"] == "gsheets://"
     assert data[0]["description"] == "A Google Sheets connector"
     assert data[0]["read_only"] is True
-
-    assert data[1]["name"] == "dj"
-    assert data[1]["URI"] == "dj://testserver/0"
-    assert data[1]["description"] == "Native DJ"
-    assert data[1]["read_only"] is True

--- a/tests/api/queries_test.py
+++ b/tests/api/queries_test.py
@@ -14,6 +14,7 @@ from sqlmodel import Session
 
 from datajunction.api.queries import dispatch_query
 from datajunction.config import Settings
+from datajunction.constants import DJ_DATABASE_ID
 from datajunction.engine import process_query
 from datajunction.models.query import (
     Database,
@@ -24,7 +25,6 @@ from datajunction.models.query import (
     QueryWithResults,
     StatementResults,
 )
-from datajunction.utils import DJ_DATABASE_ID
 
 
 def test_submit_query(session: Session, client: TestClient) -> None:

--- a/tests/cli/compile_test.py
+++ b/tests/cli/compile_test.py
@@ -364,7 +364,8 @@ async def test_run(mocker: MockerFixture, repository: Path) -> None:
     """
     mocker.patch("datajunction.cli.compile.create_db_and_tables")
     get_session = mocker.patch("datajunction.cli.compile.get_session")
-    session = get_session().__next__.return_value
+    session = get_session().__next__()
+    session.get.return_value = False
 
     index_databases = mocker.patch("datajunction.cli.compile.index_databases")
     index_nodes = mocker.patch("datajunction.cli.compile.index_nodes")
@@ -375,6 +376,7 @@ async def test_run(mocker: MockerFixture, repository: Path) -> None:
     index_nodes.assert_called_with(repository, session, False)
 
     session.commit.assert_called()
+    assert session.add.call_count == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This DJ adds two "builtin" databases to the index of databases:

1. A DJ meta-database, to issue queries against metrics (eg, `SELECT likes FROM metrics`). Before this was being returned in the API (https://github.com/DataJunction/datajunction/blob/e224c08a096f2152446fc304fb32c07420ae59af/src/datajunction/api/databases.py#L26-L39) but not stored in the index, which could be confusing.
2. A SQLite in-memory database, with cost 0. This will allow users to run queries like `SELECT 1` against the DJ meta-database without having to connect to any real database. For a query like `SELECT 1` DJ will route it to the DB with the lowest cost (since it has no nodes any database can be used), so it should always go to in-memory SQLite.