### PR TITLE
feat: index dimensions

### DIFF
--- a/examples/configs/nodes/core/comments.yaml
+++ b/examples/configs/nodes/core/comments.yaml
@@ -3,9 +3,9 @@ type: source
 columns:
   id:
     type: INT
-    dimension: core.user
   user_id:
     type: INT
+    dimension: core.users
   timestamp:
     type: DATETIME
   text:

--- a/src/datajunction/constants.py
+++ b/src/datajunction/constants.py
@@ -4,3 +4,5 @@ Useful constants.
 
 DJ_DATABASE_ID = 0
 SQLITE_DATABASE_ID = 1
+
+DEFAULT_DIMENSION_COLUMN = "id"

--- a/src/datajunction/sql/dag.py
+++ b/src/datajunction/sql/dag.py
@@ -141,3 +141,21 @@ def get_referenced_columns_from_tree(
         referenced_columns[parent].add(column)
 
     return referenced_columns
+
+
+def get_dimensions(node: Node) -> List[str]:
+    """
+    Return the available dimensions in a given node.
+    """
+    dimensions = []
+    for parent in node.parents:
+        for column in parent.columns:
+            dimensions.append(f"{parent.name}.{column.name}")
+
+            if column.dimension:
+                for dimension_column in column.dimension.columns:
+                    dimensions.append(
+                        f"{column.dimension.name}.{dimension_column.name}",
+                    )
+
+    return sorted(dimensions)

--- a/tests/api/metrics_test.py
+++ b/tests/api/metrics_test.py
@@ -81,7 +81,7 @@ def test_read_metric(session: Session, client: TestClient) -> None:
     assert response.status_code == 200
     assert data["name"] == "child"
     assert data["expression"] == "SELECT COUNT(*) FROM parent"
-    assert data["dimensions"] == ["parent.ds", "parent.user_id", "parent.foo"]
+    assert data["dimensions"] == ["parent.ds", "parent.foo", "parent.user_id"]
 
 
 def test_read_metrics_data(


### PR DESCRIPTION
Allow users to annotate dimensions in the node config (see committed example), and return them in the metrics API.

Next PR will implement grouping/filtering by dimensions in the metric and the SQL API.