### PR TITLE
feat: dimensions in the metric API

### DIFF
--- a/src/datajunction/api/metrics.py
+++ b/src/datajunction/api/metrics.py
@@ -93,7 +93,7 @@ def read_metrics_data(
     Return data for a metric.
     """
     node = get_metric(session, node_id)
-    create_query = get_query_for_node(node, d, f, database_id)
+    create_query = get_query_for_node(session, node, d, f, database_id)
 
     return save_query_and_run(
         create_query,
@@ -120,7 +120,7 @@ def read_metrics_sql(
     will be used.
     """
     node = get_metric(session, node_id)
-    create_query = get_query_for_node(node, d, f, database_id)
+    create_query = get_query_for_node(session, node, d, f, database_id)
 
     return TranslatedSQL(
         database_id=create_query.database_id,

--- a/src/datajunction/sql/build.py
+++ b/src/datajunction/sql/build.py
@@ -126,14 +126,14 @@ def get_query_for_node(  # pylint: disable=too-many-locals
 
     # base query
     node_select = get_select_for_node(node, database)
+    source = node_select.froms[0]
 
     # join with dimensions
     for dimension in dimensions.values():
-        source = node_select.froms[0]
         subquery = get_select_for_node(
             dimension,
             database,
-            {column.split(".")[-1] for column in requested_dimensions},
+            referenced_columns[dimension.name],
         ).alias(dimension.name)
         condition = find_on_clause(node, source, dimension, subquery)
         node_select = node_select.select_from(source.join(subquery, condition))

--- a/src/datajunction/sql/build.py
+++ b/src/datajunction/sql/build.py
@@ -100,7 +100,7 @@ def get_query_for_node(  # pylint: disable=too-many-locals
     requested_dimensions = set(groupbys) | get_dimensions_from_filters(filters)
     valid_dimensions = set(get_dimensions(node))
     if not requested_dimensions <= valid_dimensions:
-        invalid = requested_dimensions - valid_dimensions
+        invalid = sorted(requested_dimensions - valid_dimensions)
         plural = "s" if len(invalid) > 1 else ""
         raise Exception(f"Invalid dimension{plural}: {', '.join(invalid)}")
 

--- a/src/datajunction/sql/dag.py
+++ b/src/datajunction/sql/dag.py
@@ -4,7 +4,7 @@ DAG related functions.
 
 from collections import defaultdict
 from io import StringIO
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, DefaultDict, Dict, List, Optional, Set
 
 import asciidag.graph
 import asciidag.node
@@ -69,7 +69,8 @@ def get_computable_databases(
     This takes into consideration the node expression, since some of the columns might
     not be present in all databases.
     """
-    columns = columns or set()
+    if columns is None:
+        columns = {column.name for column in node.columns}
 
     # add all the databases where the node is explicitly materialized
     tables = [
@@ -94,7 +95,7 @@ def get_computable_databases(
 def get_referenced_columns_from_sql(
     sql: Optional[str],
     parents: List[Node],
-) -> Dict[str, Set[str]]:
+) -> DefaultDict[str, Set[str]]:
     """
     Given a SQL expression, return the referenced columns.
 
@@ -111,11 +112,11 @@ def get_referenced_columns_from_sql(
 def get_referenced_columns_from_tree(
     tree: ParseTree,
     parents: List[Node],
-) -> Dict[str, Set[str]]:
+) -> DefaultDict[str, Set[str]]:
     """
     Return the columns referenced in parents given a parse tree.
     """
-    referenced_columns: Dict[str, Set[str]] = defaultdict(set)
+    referenced_columns: DefaultDict[str, Set[str]] = defaultdict(set)
 
     parent_columns = {
         parent.name: {column.name for column in parent.columns} for parent in parents

--- a/src/datajunction/sql/transpile.py
+++ b/src/datajunction/sql/transpile.py
@@ -341,7 +341,7 @@ def get_source(  # pylint: disable=too-many-locals
     expression: Optional[str],
     parents: List[Node],
     database: Database,
-    tree: ParseTree,  # pylint: disable=unused-argument
+    tree: ParseTree,
     dialect: Optional[str] = None,
 ) -> Select:
     """


### PR DESCRIPTION
Implement dimensions in the metric API (the next PR will implement in the SQL API as well).

The way this works is simple. We annotate a column with the `dimensions` attribute, lke the `user_id` column in the `core.comments` node:

https://github.com/DataJunction/datajunction/blob/7ef9fc64607d5f9161bd5cbf4ebf46354916cbc9/examples/configs/nodes/core/comments.yaml#L1-L8

The metric `core.num_comments` now has more dimensions (from a `curl http://localhost:8000/metrics/`):

```json
{
  "id": 3,
  "name": "core.num_comments",
  "description": "Number of comments",
  "created_at": "2022-04-15T00:53:54.852111",
  "updated_at": "2022-04-15T00:53:54.852119",
  "expression": "SELECT COUNT(*) FROM core.comments",
  "dimensions": [
    "core.comments.__time",
    "core.comments.count",
    "core.comments.id",
    "core.comments.text",
    "core.comments.timestamp",
    "core.comments.user_id",
    "core.users.age",
    "core.users.country",
    "core.users.full_name",
    "core.users.gender",
    "core.users.id",
    "core.users.preferred_language",
    "core.users.secret_number"
  ]
}
```

Note that all the columns of the `core.users` dimension are now dimensions of `core.num_comments`, in addition to the dimensions that come from the parent node (`core.comments`).

Now in the metric API we can filter and group by these dimensions. For example, this query:

```bash
% curl "http://localhost:8000/metrics/3/data/?d=core.users.gender&f=core.users.age>25"
```

Returns:

```json
{
  "database_id": 3,
  "catalog": null,
  "schema": null,
  "id": "260d7b86-0261-426a-a525-e846004c4eed",
  "submitted_query": "SELECT count('*') AS count_1, \"core.users\".gender \nFROM (SELECT public.comments.id AS id, public.comments.user_id AS user_id, public.comments.timestamp AS timestamp, public.comments.text AS text \nFROM public.comments) AS \"core.comments\" JOIN (SELECT public.dim_users.id AS id, public.dim_users.full_name AS full_name, public.dim_users.age AS age, public.dim_users.country AS country, public.dim_users.gender AS gender, public.dim_users.preferred_language AS preferred_language \nFROM public.dim_users) AS \"core.users\" ON \"core.comments\".user_id = \"core.users\".id \nWHERE \"core.users\".age > 25 GROUP BY \"core.users\".gender",
  "executed_query": "SELECT count('*') AS count_1, \"core.users\".gender \nFROM (SELECT public.comments.id AS id, public.comments.user_id AS user_id, public.comments.timestamp AS timestamp, public.comments.text AS text \nFROM public.comments) AS \"core.comments\" JOIN (SELECT public.dim_users.id AS id, public.dim_users.full_name AS full_name, public.dim_users.age AS age, public.dim_users.country AS country, public.dim_users.gender AS gender, public.dim_users.preferred_language AS preferred_language \nFROM public.dim_users) AS \"core.users\" ON \"core.comments\".user_id = \"core.users\".id \nWHERE \"core.users\".age > 25 GROUP BY \"core.users\".gender",
  "scheduled": "2022-04-16T04:10:31.983073",
  "started": "2022-04-16T04:10:31.983234",
  "finished": "2022-04-16T04:10:32.076099",
  "state": "FINISHED",
  "progress": 1,
  "results": [
    {
      "sql": "SELECT count('*') AS count_1, \"core.users\".gender \nFROM (SELECT public.comments.id AS id, public.comments.user_id AS user_id, public.comments.timestamp AS timestamp, public.comments.text AS text \nFROM public.comments) AS \"core.comments\" JOIN (SELECT public.dim_users.id AS id, public.dim_users.full_name AS full_name, public.dim_users.age AS age, public.dim_users.country AS country, public.dim_users.gender AS gender, public.dim_users.preferred_language AS preferred_language \nFROM public.dim_users) AS \"core.users\" ON \"core.comments\".user_id = \"core.users\".id \nWHERE \"core.users\".age > 25 GROUP BY \"core.users\".gender",
      "columns": [
        {
          "name": "count_1",
          "type": "FLOAT"
        },
        {
          "name": "gender",
          "type": "STR"
        }
      ],
      "rows": [
        [
          6,
          "non-binary"
        ],
        [
          5,
          "male"
        ]
      ],
      "row_count": 2
    }
  ],
  "next": null,
  "previous": null,
  "errors": []
}
```

Note the query that was generated:

```sql
SELECT
  count('*') AS count_1,
  "core.users".gender
FROM (
  SELECT
    public.comments.id AS id,
    public.comments.user_id AS user_id,
    public.comments.timestamp AS timestamp,
    public.comments.text AS text
  FROM
    public.comments) AS "core.comments"
  JOIN (
    SELECT
      public.dim_users.id AS id,
      public.dim_users.full_name AS full_name,
      public.dim_users.age AS age,
      public.dim_users.country AS country,
      public.dim_users.gender AS gender,
      public.dim_users.preferred_language AS preferred_language
    FROM
      public.dim_users) AS "core.users" ON "core.comments".user_id = "core.users".id
WHERE
  "core.users".age > 25
GROUP BY
  "core.users".gender "
```