### PR TITLE
feat: dimensions in the SQL API

### DIFF
--- a/src/datajunction/typing.py
+++ b/src/datajunction/typing.py
@@ -204,14 +204,21 @@ class TableAlias(TypedDict):
 
 
 class Table(TypedDict):
-    alias: TableAlias
+    alias: Optional[TableAlias]
     args: List[Argument]
     name: List[Identifier]
     with_hints: List[Expression]
 
 
-class Relation(TypedDict):
+class Derived(TypedDict):
+    lateral: bool
+    subquery: "Body"  # type: ignore
+    alias: Optional[TableAlias]
+
+
+class Relation(TypedDict, total=False):
     Table: Table
+    Derived: Derived
 
 
 class JoinConstraint(TypedDict):

--- a/tests/sql/build_test.py
+++ b/tests/sql/build_test.py
@@ -3,9 +3,6 @@ Tests for ``datajunction.sql.build``.
 """
 # pylint: disable=invalid-name, too-many-lines
 
-from collections import defaultdict
-from typing import Dict, Set
-
 import pytest
 from pytest_mock import MockerFixture
 from sqlalchemy.engine import create_engine
@@ -17,9 +14,9 @@ from datajunction.models.node import Node, NodeType
 from datajunction.models.table import Table
 from datajunction.sql.build import (
     find_on_clause,
-    get_database_for_nodes,
     get_dimensions_from_filters,
     get_filter,
+    get_join_columns,
     get_query_for_node,
     get_query_for_sql,
 )
@@ -43,6 +40,7 @@ def test_get_query_for_node(mocker: MockerFixture) -> None:
                 columns=[Column(name="cnt", type=ColumnType.INT)],
             ),
         ],
+        type=NodeType.METRIC,
         expression="SELECT COUNT(*) AS cnt FROM A",
         parents=[parent],
     )
@@ -84,6 +82,7 @@ def test_get_query_for_node_with_groupbys(mocker: MockerFixture) -> None:
 
     child = Node(
         name="B",
+        type=NodeType.METRIC,
         expression="SELECT COUNT(*) AS cnt FROM A",
         parents=[parent],
     )
@@ -122,6 +121,7 @@ def test_get_query_for_node_specify_database(mocker: MockerFixture) -> None:
                 columns=[Column(name="cnt", type=ColumnType.INT)],
             ),
         ],
+        type=NodeType.METRIC,
         expression="SELECT COUNT(*) AS cnt FROM A",
         parents=[parent],
         columns=[Column(name="cnt", type=ColumnType.INT)],
@@ -160,12 +160,13 @@ def test_get_query_for_node_no_databases(mocker: MockerFixture) -> None:
                 columns=[Column(name="one", type=ColumnType.STR)],
             ),
         ],
+        type=NodeType.METRIC,
         expression="SELECT COUNT(*) AS cnt FROM A",
         parents=[parent],
         columns=[Column(name="one", type=ColumnType.STR)],
     )
 
-    mocker.patch("datajunction.sql.build.get_computable_databases", return_value=set())
+    mocker.patch("datajunction.sql.dag.get_computable_databases", return_value=set())
     session = mocker.MagicMock()
 
     with pytest.raises(Exception) as excinfo:
@@ -222,6 +223,7 @@ def test_get_query_for_node_with_dimensions(mocker: MockerFixture) -> None:
 
     child = Node(
         name="core.num_comments",
+        type=NodeType.METRIC,
         expression="SELECT COUNT(*) FROM core.comments",
         parents=[parent],
     )
@@ -337,6 +339,7 @@ def test_get_query_for_node_with_multiple_dimensions(mocker: MockerFixture) -> N
 
     child = Node(
         name="core.num_comments",
+        type=NodeType.METRIC,
         expression="SELECT COUNT(*) FROM core.comments",
         parents=[parent],
     )
@@ -431,6 +434,7 @@ def test_get_query_for_sql(mocker: MockerFixture, session: Session) -> None:
 
     B = Node(
         name="B",
+        type=NodeType.METRIC,
         expression="SELECT COUNT(*) AS cnt FROM A",
         parents=[A],
     )
@@ -449,6 +453,107 @@ def test_get_query_for_sql(mocker: MockerFixture, session: Session) -> None:
 FROM (SELECT "A".one AS one, "A".two AS two{space}
 FROM "A") AS "A"'''
     )
+
+
+def test_get_query_for_sql_with_dimensions(
+    mocker: MockerFixture,
+    session: Session,
+) -> None:
+    """
+    Test ``get_query_for_sql`` with dimensions in the query.
+    """
+    get_session = mocker.patch("datajunction.sql.build.get_session")
+    get_session().__next__.return_value = session
+
+    database = Database(id=1, name="slow", URI="sqlite://", cost=1.0)
+
+    dimension = Node(
+        name="core.users",
+        type=NodeType.DIMENSION,
+        tables=[
+            Table(
+                database=database,
+                table="dim_users",
+                columns=[
+                    Column(name="id", type=ColumnType.INT),
+                    Column(name="age", type=ColumnType.INT),
+                    Column(name="gender", type=ColumnType.STR),
+                ],
+            ),
+        ],
+        columns=[
+            Column(name="id", type=ColumnType.INT),
+            Column(name="age", type=ColumnType.INT),
+            Column(name="gender", type=ColumnType.STR),
+        ],
+    )
+
+    parent = Node(
+        name="core.comments",
+        tables=[
+            Table(
+                database=database,
+                table="comments",
+                columns=[
+                    Column(name="ds", type=ColumnType.STR),
+                    Column(name="user_id", type=ColumnType.INT),
+                    Column(name="text", type=ColumnType.STR),
+                ],
+            ),
+        ],
+        columns=[
+            Column(name="ds", type=ColumnType.STR),
+            Column(name="user_id", type=ColumnType.INT, dimension=dimension),
+            Column(name="text", type=ColumnType.STR),
+        ],
+    )
+
+    child = Node(
+        name="core.num_comments",
+        type=NodeType.METRIC,
+        expression="SELECT COUNT(*) FROM core.comments",
+        parents=[parent],
+    )
+
+    engine = create_engine(database.URI)
+    connection = engine.connect()
+    connection.execute("CREATE TABLE dim_users (id INTEGER, age INTEGER, gender TEXT)")
+    connection.execute("CREATE TABLE comments (ds TEXT, user_id INTEGER, text TEXT)")
+    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+
+    session.add(child)
+    session.add(dimension)
+    session.commit()
+
+    sql = """
+SELECT "core.users.gender", "core.num_comments"
+FROM metrics
+WHERE "core.users.age" > 25
+GROUP BY "core.users.gender"
+    """
+    create_query = get_query_for_sql(sql)
+
+    assert create_query.database_id == 1
+
+    space = " "
+    assert (
+        create_query.submitted_query
+        == f"""SELECT "core.users".gender, count('*') AS "core.num_comments"{space}
+FROM (SELECT comments.ds AS ds, comments.user_id AS user_id, comments.text AS text{space}
+FROM comments) AS "core.comments" JOIN (SELECT dim_users.id AS id, dim_users.age AS age, dim_users.gender AS gender{space}
+FROM dim_users) AS "core.users" ON "core.comments".user_id = "core.users".id{space}
+WHERE "core.users".age > 25 GROUP BY "core.users".gender"""
+    )
+
+    sql = """
+SELECT "core.users.invalid", "core.num_comments"
+FROM metrics
+WHERE "core.users.age" > 25
+GROUP BY "core.users.invalid"
+    """
+    with pytest.raises(Exception) as excinfo:
+        get_query_for_sql(sql)
+    assert str(excinfo.value) == "Invalid dimension: core.users.invalid"
 
 
 def test_get_query_for_sql_compound_names(
@@ -484,6 +589,7 @@ def test_get_query_for_sql_compound_names(
 
     B = Node(
         name="core.B",
+        type=NodeType.METRIC,
         expression="SELECT COUNT(*) AS cnt FROM core.A",
         parents=[A],
     )
@@ -549,6 +655,7 @@ def test_get_query_for_sql_multiple_databases(
 
     B = Node(
         name="B",
+        type=NodeType.METRIC,
         expression="SELECT COUNT(*) AS cnt FROM A",
         parents=[A],
     )
@@ -607,12 +714,14 @@ def test_get_query_for_sql_multiple_metrics(
 
     B = Node(
         name="B",
+        type=NodeType.METRIC,
         expression="SELECT COUNT(*) AS cnt FROM A",
         parents=[A],
     )
     session.add(B)
     C = Node(
         name="C",
+        type=NodeType.METRIC,
         expression="SELECT MAX(one) AS max_one FROM A",
         parents=[A],
     )
@@ -670,12 +779,14 @@ def test_get_query_for_sql_non_identifiers(
 
     B = Node(
         name="B",
+        type=NodeType.METRIC,
         expression="SELECT COUNT(*) AS cnt FROM A",
         parents=[A],
     )
     session.add(B)
     C = Node(
         name="C",
+        type=NodeType.METRIC,
         expression="SELECT MAX(one) AS max_one FROM A",
         parents=[A],
     )
@@ -736,12 +847,14 @@ def test_get_query_for_sql_different_parents(
     )
     C = Node(
         name="C",
+        type=NodeType.METRIC,
         expression="SELECT COUNT(*) AS cnt FROM A",
         parents=[A],
     )
     session.add(C)
     D = Node(
         name="D",
+        type=NodeType.METRIC,
         expression="SELECT MAX(one) AS max_one FROM A",
         parents=[B],
     )
@@ -751,7 +864,7 @@ def test_get_query_for_sql_different_parents(
     sql = "SELECT C, D FROM metrics"
     with pytest.raises(Exception) as excinfo:
         get_query_for_sql(sql)
-    assert str(excinfo.value) == "All metrics should have the same parents"
+    assert str(excinfo.value) == "Metrics C and D have non-shared parents"
 
 
 def test_get_query_for_sql_not_metric(mocker: MockerFixture, session: Session) -> None:
@@ -788,7 +901,7 @@ def test_get_query_for_sql_not_metric(mocker: MockerFixture, session: Session) -
     sql = "SELECT B FROM metrics"
     with pytest.raises(Exception) as excinfo:
         get_query_for_sql(sql)
-    assert str(excinfo.value) == "Not a valid metric: B"
+    assert str(excinfo.value) == "Invalid dimension: B"
 
 
 def test_get_query_for_sql_no_databases(
@@ -808,6 +921,7 @@ def test_get_query_for_sql_no_databases(
 
     B = Node(
         name="B",
+        type=NodeType.METRIC,
         expression="SELECT COUNT(*) AS cnt FROM A",
         parents=[A],
     )
@@ -850,6 +964,7 @@ def test_get_query_for_sql_alias(mocker: MockerFixture, session: Session) -> Non
 
     B = Node(
         name="B",
+        type=NodeType.METRIC,
         expression="SELECT COUNT(*) AS cnt FROM A",
         parents=[A],
     )
@@ -903,6 +1018,7 @@ def test_get_query_for_sql_where_groupby(
 
     num_comments = Node(
         name="core.num_comments",
+        type=NodeType.METRIC,
         expression="SELECT COUNT(*) FROM core.comments",
         parents=[comments],
     )
@@ -961,6 +1077,7 @@ def test_get_query_for_sql_invalid_column(
 
     num_comments = Node(
         name="core.num_comments",
+        type=NodeType.METRIC,
         expression="SELECT COUNT(*) FROM core.comments",
         parents=[comments],
     )
@@ -973,39 +1090,7 @@ WHERE "core.some_other_parent.user_id" > 1
     """
     with pytest.raises(Exception) as excinfo:
         get_query_for_sql(sql)
-    assert str(excinfo.value) == "Invalid identifier: core.some_other_parent"
-
-
-def test_get_database_for_nodes(mocker: MockerFixture) -> None:
-    """
-    Test ``get_database_for_nodes``.
-    """
-    database_1 = Database(id=1, name="fast", URI="sqlite://", cost=1.0)
-    database_2 = Database(id=2, name="slow", URI="sqlite://", cost=10.0)
-
-    get_session = mocker.patch("datajunction.sql.build.get_session")
-    session = get_session().__next__()
-    session.exec().all.return_value = [database_1, database_2]
-
-    parent = Node(
-        name="parent",
-        tables=[
-            Table(
-                database=database_2,
-                table="comments",
-                columns=[
-                    Column(name="user_id", type=ColumnType.INT),
-                    Column(name="comment", type=ColumnType.STR),
-                ],
-            ),
-        ],
-    )
-
-    referenced_columns: Dict[str, Set[str]] = defaultdict(set)
-    assert get_database_for_nodes(session, [parent], referenced_columns) == database_2
-
-    # without parents, return the cheapest DB
-    assert get_database_for_nodes(session, [], referenced_columns) == database_1
+    assert str(excinfo.value) == "Invalid dimension: core.some_other_parent.user_id"
 
 
 def test_get_dimensions_from_filters() -> None:
@@ -1207,3 +1292,71 @@ def test_find_on_clause_parent_invalid_reference(mocker: MockerFixture) -> None:
         str(excinfo.value)
         == "Node core.num_comments has no columns with dimension core.users"
     )
+
+
+def test_get_join_columns() -> None:
+    """
+    Test ``get_join_columns``.
+    """
+    database = Database(id=1, name="one", URI="sqlite://")
+
+    dimension = Node(
+        name="core.users",
+        type=NodeType.DIMENSION,
+        tables=[
+            Table(
+                database=database,
+                table="dim_users",
+                columns=[
+                    Column(name="id", type=ColumnType.INT),
+                    Column(name="age", type=ColumnType.INT),
+                    Column(name="gender", type=ColumnType.STR),
+                ],
+            ),
+        ],
+        columns=[
+            Column(name="id", type=ColumnType.INT),
+            Column(name="age", type=ColumnType.INT),
+            Column(name="gender", type=ColumnType.STR),
+        ],
+    )
+
+    orphan = Node(name="orphan")
+
+    with pytest.raises(Exception) as excinfo:
+        get_join_columns(orphan, dimension)
+    assert str(excinfo.value) == "Node orphan has no columns with dimension core.users"
+
+    parent_without_columns = Node(name="parent_without_columns")
+    broken = Node(name="broken", parents=[parent_without_columns])
+
+    with pytest.raises(Exception) as excinfo:
+        get_join_columns(broken, dimension)
+    assert str(excinfo.value) == "Node broken has no columns with dimension core.users"
+
+    parent = Node(
+        name="parent",
+        tables=[
+            Table(
+                database=database,
+                table="comments",
+                columns=[
+                    Column(name="ds", type=ColumnType.STR),
+                    Column(name="user_id", type=ColumnType.INT),
+                    Column(name="text", type=ColumnType.STR),
+                ],
+            ),
+        ],
+        columns=[
+            Column(name="ds", type=ColumnType.STR),
+            Column(name="user_id", type=ColumnType.INT, dimension=dimension),
+            Column(name="text", type=ColumnType.STR),
+        ],
+    )
+
+    child = Node(name="child", parents=[parent_without_columns, parent])
+
+    parent_name, column_name, dimension_column = get_join_columns(child, dimension)
+    assert parent_name == "parent"
+    assert column_name == "user_id"
+    assert dimension_column == "id"


### PR DESCRIPTION
Allow dimensions in DQL:

```python
from sqlalchemy.engine import create_engine

query = '''
    SELECT
        "core.users.gender", "core.num_comments"
    FROM
        metrics
    GROUP BY
        "core.users.gender"
'''
engine = create_engine("dj://localhost:8000/0")
connection = engine.connect()

for row in connection.execute(query):
    print(row)
```

Prints:

```
('female', 5)
('non-binary', 9)
('male', 7)
```