### PR TITLE
feat: implement `DATE_TRUNC`

### DIFF
--- a/src/datajunction/sql/functions.py
+++ b/src/datajunction/sql/functions.py
@@ -33,20 +33,49 @@ The ``dialect`` can be used to build custom functions.
 
 """
 
-# pylint: disable=unused-argument, missing-function-docstring, arguments-differ
+# pylint: disable=unused-argument, missing-function-docstring, arguments-differ, too-many-return-statements
 
 import abc
 from typing import TYPE_CHECKING, Any, Dict, Optional, Type, Union
 
-from sqlalchemy.sql import func
+from sqlalchemy.sql import cast, func
+from sqlalchemy.sql.expression import TextClause
 from sqlalchemy.sql.functions import Function as SqlaFunction
 from sqlalchemy.sql.schema import Column as SqlaColumn
+from sqlalchemy.sql.sqltypes import TIMESTAMP
 
 from datajunction.typing import ColumnType
 
 if TYPE_CHECKING:
     from datajunction.models.column import Column
     from datajunction.sql.lib import Wildcard
+
+
+# a subset of the SQLAlchemy dialects that support ``DATE_TRUNC``
+DATE_TRUNC_DIALECTS = {
+    "postgresql",
+    "trino",
+    "presto",
+}
+
+# family of SQLite dialects
+SQLITE_DIALECTS = {
+    "sqlite",
+    "shillelagh",
+    "gsheets",
+}
+
+# Druid uses ISO durations for ``DATE_TRUNC``
+ISO_DURATIONS = {
+    "second": "PT1S",
+    "minute": "PT1M",
+    "hour": "PT1H",
+    "day": "P1D",
+    "week": "P1W",
+    "month": "P1M",
+    "quarter": "P3M",
+    "year": "P1Y",
+}
 
 
 class Function:  # pylint: disable=too-few-public-methods
@@ -87,6 +116,79 @@ class Count(Function):
         return func.count(argument)
 
 
+class DateTrunc(Function):
+    """
+    The ``DATE_TRUNC`` function.
+
+    There's no standard ``DATE_TRUNC`` function, so we implement it for every dialect that
+    doesn't support it.
+    """
+
+    is_aggregation = False
+
+    @staticmethod
+    def infer_type(resolution: str, column: "Column") -> ColumnType:  # type: ignore
+        return ColumnType.DATETIME
+
+    # pylint: disable=too-many-branches
+    @staticmethod
+    def get_sqla_function(  # type: ignore
+        resolution: TextClause,
+        column: SqlaColumn,
+        *,
+        dialect: Optional[str] = None,
+    ) -> SqlaFunction:
+        if dialect is None:
+            raise Exception("A dialect is needed for `DATE_TRUNC`")
+
+        if dialect in DATE_TRUNC_DIALECTS:
+            return func.date_trunc(resolution, column)
+
+        if dialect in SQLITE_DIALECTS:
+            if str(resolution) == "second":
+                return func.datetime(func.strftime("%Y-%m-%dT%H:%M:%S", column))
+            if str(resolution) == "minute":
+                return func.datetime(func.strftime("%Y-%m-%dT%H:%M:00", column))
+            if str(resolution) == "hour":
+                return func.datetime(func.strftime("%Y-%m-%dT%H:00:00", column))
+            if str(resolution) == "day":
+                return func.datetime(column, "start of day")
+            if str(resolution) == "week":
+                # https://stackoverflow.com/a/51666243
+                return func.datetime(
+                    column,
+                    "1 day",
+                    "weekday 0",
+                    "-7 days",
+                    "start of day",
+                )
+            if str(resolution) == "month":
+                return func.datetime(column, "start of month")
+            if str(resolution) == "quarter":
+                return func.datetime(
+                    column,
+                    func.printf("-%d month", (func.strftime("%m", column) - 1) % 3 + 1),
+                )
+            if str(resolution) == "year":
+                return func.datetime(column, "start of year")
+
+            raise Exception(f"Resolution {resolution} not supported by SQLite")
+
+        if dialect == "druid":
+            if str(resolution) not in ISO_DURATIONS:
+                raise Exception(f"Resolution {resolution} not supported by Druid")
+
+            return func.time_floor(
+                cast(column, TIMESTAMP), ISO_DURATIONS[str(resolution)],
+            )
+
+        raise Exception(
+            f"Dialect {dialect} doesn't support `DATE_TRUNC`. Please file a ticket at "
+            "https://github.com/DataJunction/datajunction/issues/new?"
+            f"title=date_trunc+for+{dialect}.",
+        )
+
+
 class Max(Function):
     """
     The ``MAX`` function.
@@ -109,5 +211,6 @@ class Max(Function):
 
 function_registry: Dict[str, Type[Function]] = {
     "COUNT": Count,
+    "DATE_TRUNC": DateTrunc,
     "MAX": Max,
 }

--- a/src/datajunction/typing.py
+++ b/src/datajunction/typing.py
@@ -149,7 +149,7 @@ class Function(TypedDict):
     args: List[Argument]
     distinct: bool
     name: List[Identifier]
-    over: Over
+    over: Optional[Over]
 
 
 class ExpressionWithAlias(TypedDict):

--- a/tests/sql/inference_test.py
+++ b/tests/sql/inference_test.py
@@ -51,14 +51,14 @@ def test_evaluate_expression() -> None:
                 database=Database(name="test", URI="sqlite://"),
                 table="A",
                 columns=[
-                    Column(name="ds", type=ColumnType.STR),
+                    Column(name="ds", type=ColumnType.DATETIME),
                     Column(name="user_id", type=ColumnType.INT),
                     Column(name="foo", type=ColumnType.FLOAT),
                 ],
             ),
         ],
         columns=[
-            Column(name="ds", type=ColumnType.STR),
+            Column(name="ds", type=ColumnType.DATETIME),
             Column(name="user_id", type=ColumnType.INT),
             Column(name="foo", type=ColumnType.FLOAT),
         ],
@@ -66,7 +66,15 @@ def test_evaluate_expression() -> None:
 
     assert evaluate_expression([node_a], get_expression("SELECT ds")) == Column(
         name="ds",
-        type=ColumnType.STR,
+        type=ColumnType.DATETIME,
+    )
+    assert evaluate_expression(
+        [node_a],
+        get_expression("SELECT DATE_TRUNC('day', ds)"),
+        "ds",
+    ) == Column(
+        name="ds",
+        type=ColumnType.DATETIME,
     )
     assert (
         evaluate_expression(


### PR DESCRIPTION
Implement `DATE_TRUNC` for:

1. Dialects that use `date_trunc`: Presto, Trino, Postgres.
2. SQLite based dialects: SQLite, Shillelagh, GSheets.
3. Druid, via `TIME_FLOOR`.