### PR TITLE
fix: SQLAlchemy fixes

### DIFF
--- a/src/datajunction/sql/dbapi/connection.py
+++ b/src/datajunction/sql/dbapi/connection.py
@@ -37,12 +37,10 @@ class Connection:
     @check_closed
     def commit(self) -> None:
         """Commit any pending transaction to the database."""
-        raise NotSupportedError("Commits are not supported")
 
     @check_closed
     def rollback(self) -> None:
         """Rollback any transactions."""
-        raise NotSupportedError("Rollbacks are not supported")
 
     @check_closed
     def cursor(self) -> Cursor:

--- a/src/datajunction/sql/functions.py
+++ b/src/datajunction/sql/functions.py
@@ -179,7 +179,8 @@ class DateTrunc(Function):
                 raise Exception(f"Resolution {resolution} not supported by Druid")
 
             return func.time_floor(
-                cast(column, TIMESTAMP), ISO_DURATIONS[str(resolution)],
+                cast(column, TIMESTAMP),
+                ISO_DURATIONS[str(resolution)],
             )
 
         raise Exception(

--- a/tests/sql/dbapi/connection_test.py
+++ b/tests/sql/dbapi/connection_test.py
@@ -3,12 +3,10 @@ Tests for ``datajunction.sql.dbapi.connection``.
 """
 # pylint: disable=redefined-builtin, invalid-name
 
-import pytest
 from pytest_mock import MockerFixture
 from yarl import URL
 
 from datajunction.sql.dbapi.connection import connect
-from datajunction.sql.dbapi.exceptions import NotSupportedError
 
 
 def test_connection() -> None:
@@ -32,13 +30,9 @@ def test_connection() -> None:
 
     connection = connect(URL("http://localhost:8000/"))
 
-    with pytest.raises(NotSupportedError) as excinfo:
-        connection.commit()
-    assert str(excinfo.value) == "Commits are not supported"
-
-    with pytest.raises(NotSupportedError) as excinfo:
-        connection.rollback()
-    assert str(excinfo.value) == "Rollbacks are not supported"
+    # these are no-ops
+    assert connection.commit() is None
+    assert connection.rollback() is None
 
     with connection:
         assert not connection.closed


### PR DESCRIPTION
Some fixes while testing the Apache Superset integration via SQLAlchemy:

- Builder: `SELECT 1` no longer worked because we assumed at least one metric, fixed.
- Builder/tranpiler: added support for `ORDER BY` (closes https://github.com/DataJunction/datajunction/issues/42).
- DB API: `commit` and `rollback` no longer raise exceptions
- Dialect: fix `get_columns` to return type instances.
- Dialect: add dummy methods that Superset need.