### PR TITLE
fix: `DATE_TRUNC`

### DIFF
--- a/src/datajunction/sql/functions.py
+++ b/src/datajunction/sql/functions.py
@@ -142,7 +142,7 @@ class DateTrunc(Function):
             raise Exception("A dialect is needed for `DATE_TRUNC`")
 
         if dialect in DATE_TRUNC_DIALECTS:
-            return func.date_trunc(resolution, column)
+            return func.date_trunc(str(resolution), column)
 
         if dialect in SQLITE_DIALECTS:
             if str(resolution) == "second":

--- a/tests/sql/transpile_test.py
+++ b/tests/sql/transpile_test.py
@@ -484,7 +484,7 @@ def test_date_trunc() -> None:
 
     assert (
         query_to_string(get_function(function, source, dialect="postgresql"))
-        == "date_trunc(second, anon_1.col)"
+        == "date_trunc('second', anon_1.col)"
     )
 
 


### PR DESCRIPTION
Found a problem with `DATE_TRUNC`, we were passing the resolution as a `TextClause` and the identifier preparer would print it without quotes (since it was not a string). Now the query renders correctly, with the resolution quoted as a string should be.

Also fixed a problem with `ORDER BY` not working with columns, only metrics.