### PR TITLE
feat: proper error handling

### DIFF
--- a/src/datajunction/errors.py
+++ b/src/datajunction/errors.py
@@ -1,0 +1,158 @@
+"""
+Errors and warnings.
+"""
+
+from enum import Enum
+from typing import Any, Dict, List, Literal, Optional, TypedDict
+
+from sqlmodel import SQLModel
+
+
+class ErrorCode(int, Enum):
+    """
+    Error codes.
+    """
+
+    UNKWNON_ERROR = 0
+
+    # metric API
+    INVALID_FILTER_PATTERN = 100
+    INVALID_COLUMN_IN_FILTER = 101
+    INVALID_VALUE_IN_FILTER = 102
+
+
+class DJErrorType(TypedDict):
+    """
+    Type for serialized errors.
+    """
+
+    code: int
+    message: str
+    debug: Optional[Dict[str, Any]]
+
+
+class DJError(SQLModel):
+    """
+    An error.
+    """
+
+    code: ErrorCode
+    message: str
+    debug: Optional[Dict[str, Any]]
+
+
+class DJWarningType(TypedDict):
+    """
+    Type for serialized warnings.
+    """
+
+    code: Optional[int]
+    message: str
+    debug: Optional[Dict[str, Any]]
+
+
+class DJWarning(SQLModel):
+    """
+    A warning.
+    """
+
+    code: Optional[ErrorCode] = None
+    message: str
+    debug: Optional[Dict[str, Any]]
+
+
+DBAPIExceptions = Literal[
+    "Warning",
+    "Error",
+    "InterfaceError",
+    "DatabaseError",
+    "DataError",
+    "OperationalError",
+    "IntegrityError",
+    "InternalError",
+    "ProgrammingError",
+    "NotSupportedError",
+]
+
+
+class DJExceptionType(TypedDict):
+    """
+    Type for serialized exceptions.
+    """
+
+    message: Optional[str]
+    errors: List[DJErrorType]
+    warnings: List[DJWarningType]
+
+    dbapi_exception: DBAPIExceptions
+    http_status_code: int
+
+
+class DJException(Exception):
+    """
+    Base class for errors.
+    """
+
+    message: str
+    errors: List[DJError]
+    warnings: List[DJWarning]
+
+    # exception that should be raised when ``DJException`` is caught by the DB API cursor
+    dbapi_exception: DBAPIExceptions = "Error"
+
+    # status code that should be returned when ``DJException`` is caught by the API layer
+    http_status_code: int = 500
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        message: Optional[str] = None,
+        errors: Optional[List[DJError]] = None,
+        warnings: Optional[List[DJWarning]] = None,
+        dbapi_exception: Optional[DBAPIExceptions] = None,
+        http_status_code: Optional[int] = None,
+    ):
+        self.errors = errors or []
+        self.warnings = warnings or []
+        self.message = message or "\n".join(error.message for error in self.errors)
+
+        if dbapi_exception is not None:
+            self.dbapi_exception = dbapi_exception
+        if http_status_code is not None:
+            self.http_status_code = http_status_code
+
+        super().__init__(self.message)
+
+    def to_dict(self) -> DJExceptionType:
+        """
+        Convert to dict.
+        """
+        return {
+            "message": self.message,
+            "errors": [error.dict() for error in self.errors],
+            "warnings": [warning.dict() for warning in self.warnings],
+            "dbapi_exception": self.dbapi_exception,
+            "http_status_code": self.http_status_code,
+        }
+
+    @classmethod
+    def from_dict(cls, content: DJExceptionType) -> "DJException":
+        """
+        Instantiate class from a dict.
+        """
+        return cls(
+            message=content["message"],
+            errors=[DJError(**error) for error in content["errors"]],
+            warnings=[DJWarning(**warning) for warning in content["warnings"]],
+            dbapi_exception=content["dbapi_exception"],
+            http_status_code=content["http_status_code"],
+        )
+
+
+class DJInvalidInputException(DJException):
+
+    """
+    Exception raised when the input provided by the user is invalid.
+    """
+
+    dbapi_exception: DBAPIExceptions = "ProgrammingError"
+    http_status_code: int = 422

--- a/tests/errors_test.py
+++ b/tests/errors_test.py
@@ -1,0 +1,22 @@
+"""
+Tests errors.
+"""
+
+from datajunction.errors import DJException
+
+
+def test_dj_exception() -> None:
+    """
+    Test the base ``DJException``.
+    """
+    exc = DJException()
+    assert exc.dbapi_exception == "Error"
+    assert exc.http_status_code == 500
+
+    exc = DJException(dbapi_exception="InternalError")
+    assert exc.dbapi_exception == "InternalError"
+    assert exc.http_status_code == 500
+
+    exc = DJException(dbapi_exception="ProgrammingError", http_status_code=400)
+    assert exc.dbapi_exception == "ProgrammingError"
+    assert exc.http_status_code == 400

--- a/tests/sql/build_test.py
+++ b/tests/sql/build_test.py
@@ -389,15 +389,11 @@ def test_get_filter(mocker: MockerFixture) -> None:
 
     with pytest.raises(Exception) as excinfo:
         get_filter(columns, "invalid")
-    assert str(excinfo.value) == "Invalid filter: invalid"
+    assert str(excinfo.value) == 'The filter "invalid" is invalid'
 
     with pytest.raises(Exception) as excinfo:
         get_filter(columns, "b>0")
     assert str(excinfo.value) == "Invalid column name: b"
-
-    with pytest.raises(Exception) as excinfo:
-        get_filter(columns, "a>=0")
-    assert str(excinfo.value) == "Invalid operation: >= (valid: >)"
 
     with pytest.raises(Exception) as excinfo:
         get_filter(columns, "a>open('/etc/passwd').read()")
@@ -1468,7 +1464,7 @@ def test_get_dimensions_from_filters() -> None:
 
     with pytest.raises(Exception) as excinfo:
         get_dimensions_from_filters(["aaaa"])
-    assert str(excinfo.value) == "Invalid filter: aaaa"
+    assert str(excinfo.value) == 'The filter "aaaa" is invalid'
 
 
 def test_find_on_clause(mocker: MockerFixture) -> None:


### PR DESCRIPTION
Add support for error handling. We have a base class `DJException` for exception, which can have multiple errors (with error code) and/or multiple warnings. Exceptions also have an `http_status_code` attribute, so that the FastAPI layer can return the proper status, and a `dbapi_exception` attribute, so that the DB API cursor can raise the proper exception based on the HTTP response.