### PR TITLE
feat: improve `docker-compose.yml`

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,0 @@
-NAME="Example DJ server"
-DESCRIPTION="A simple DJ server running in Docker"
-INDEX=sqlite:///examples/configs/dj.db
-REPOSITORY=examples/configs
-REDIS_CACHE=redis://host.docker.internal:6379/0
-CELERY_BROKER=redis://host.docker.internal:6379/1

--- a/.env-docker
+++ b/.env-docker
@@ -1,0 +1,6 @@
+NAME="Example DJ server"
+DESCRIPTION="A simple DJ server running in Docker"
+INDEX=postgresql://username:FoolishPassword@postgres_metadata:5432/dj
+REPOSITORY=examples/configs
+REDIS_CACHE=redis://query_broker:6379/0
+CELERY_BROKER=redis://query_broker:6379/1

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ ENV/
 *.sqlite
 *.db
 *.swp
+
+# https://pypi.org/project/python-dotenv/
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,24 +27,30 @@ volumes:
   router_var: {}
   druid_shared: {}
   postgres_data: {}
+  postgres_metadata: {}
   redis_data: {}
 
 
 services:
   dj:
     container_name: dj
+    environment:
+      - DOTENV_FILE=.env-docker
     build: .
     volumes:
       - .:/code
     ports:
       - "8000:8000"
     depends_on:
-      - redis
+      - postgres_metadata
       - postgres_examples
+      - redis
       - druid_coordinator
 
   celery:
     container_name: celery
+    environment:
+      - DOTENV_FILE=.env-docker
     build: .
     volumes:
       - .:/code
@@ -54,6 +60,8 @@ services:
 
   watchdog:
     container_name: watchdog
+    environment:
+      - DOTENV_FILE=.env-docker
     build: .
     volumes:
       - .:/code
@@ -69,6 +77,18 @@ services:
       - "6379:6379"
     volumes:
       - redis_data:/data
+
+  postgres_metadata:
+    container_name: postgres_metadata
+    image: postgres:latest
+    volumes:
+      - postgres_metadata:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=FoolishPassword
+      - POSTGRES_USER=username
+      - POSTGRES_DB=dj
+    ports:
+      - "5434:5432"
 
   postgres_examples:
     container_name: postgres_examples

--- a/examples/configs/databases/druid.yaml
+++ b/examples/configs/databases/druid.yaml
@@ -1,4 +1,4 @@
 description: An Apache Druid database
-URI: druid://host.docker.internal:8082/druid/v2/sql/
+URI: druid://druid_broker:8082/druid/v2/sql/
 read_only: true
 cost: 1

--- a/examples/configs/databases/postgres.yaml
+++ b/examples/configs/databases/postgres.yaml
@@ -1,4 +1,4 @@
 description: A Postgres database
-URI: postgresql://username:FoolishPassword@host.docker.internal:5433/examples
+URI: postgresql://username:FoolishPassword@postgres_examples:5432/examples
 read_only: false
 cost: 10

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ sqlalchemy==1.4.25
 sqlalchemy-utils==0.38.2
 sqlalchemy2-stubs==0.0.2a19
 sqlmodel==0.0.5
-sqloxide==0.1.13
+sqloxide==0.1.15
 sqlparse==0.4.2
 starlette==0.16.0
 typing-extensions==4.0.1

--- a/src/datajunction/utils.py
+++ b/src/datajunction/utils.py
@@ -50,7 +50,8 @@ def get_settings() -> Settings:
     """
     Return a cached settings object.
     """
-    load_dotenv()
+    dotenv_file = os.environ.get("DOTENV_FILE", ".env")
+    load_dotenv(dotenv_file)
     return Settings()
 
 
@@ -59,8 +60,7 @@ def get_engine() -> Engine:
     Create the metadata engine.
     """
     settings = get_settings()
-    connect_args = {"check_same_thread": False}
-    engine = create_engine(settings.index, echo=False, connect_args=connect_args)
+    engine = create_engine(settings.index)
 
     return engine
 

--- a/tests/cli/compile_test.py
+++ b/tests/cli/compile_test.py
@@ -73,7 +73,7 @@ async def test_index_databases(repository: Path, session: Session) -> None:
             "updated_at": datetime(2021, 1, 2, 0, 0),
             "name": "druid",
             "description": "An Apache Druid database",
-            "URI": "druid://host.docker.internal:8082/druid/v2/sql/",
+            "URI": "druid://druid_broker:8082/druid/v2/sql/",
             "read_only": True,
         },
         {
@@ -93,7 +93,7 @@ async def test_index_databases(repository: Path, session: Session) -> None:
             "updated_at": datetime(2021, 1, 2, 0, 0),
             "name": "postgres",
             "description": "A Postgres database",
-            "URI": "postgresql://username:FoolishPassword@host.docker.internal:5433/examples",
+            "URI": "postgresql://username:FoolishPassword@postgres_examples:5432/examples",
             "read_only": False,
         },
     ]
@@ -212,12 +212,12 @@ async def test_index_nodes(
     mocker.patch("datajunction.cli.compile.update_node_config")
 
     session.add(
-        Database(name="druid", URI="druid://host.docker.internal:8082/druid/v2/sql/"),
+        Database(name="druid", URI="druid://druid_broker:8082/druid/v2/sql/"),
     )
     session.add(
         Database(
             name="postgres",
-            URI="postgresql://username:FoolishPassword@host.docker.internal:5433/examples",
+            URI="postgresql://username:FoolishPassword@postgres_examples:5432/examples",
         ),
     )
     session.add(Database(name="gsheets", URI="gsheets://"))


### PR DESCRIPTION
- Rename `.env` to `.env-docker`, so that devs can have their own `.env` if they want.
- Change the DJ in `docker-compose.yml` to use Postgres for metadata, instead of SQLite.
- Use Docker hostnames instead of `host.docker.internal`.