### PR TITLE
feat: simple integration test

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,4 +30,4 @@ jobs:
         pip install -e '.[testing]'
     - name: Test with pytest
       run: |
-        pytest --cov-fail-under=100 --cov=src/datajunction -vv tests/ --doctest-modules src/datajunction
+        pytest --cov-fail-under=100 --cov=src/datajunction -vv tests/ --doctest-modules src/datajunction --without-integration --without-slow-integration

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,10 @@ pyenv: .python-version
 	touch .python-version
 
 test: pyenv
-	pytest --cov=src/datajunction -vv tests/ --doctest-modules src/datajunction
+	pytest --cov=src/datajunction -vv tests/ --doctest-modules src/datajunction --without-integration --without-slow-integration
+
+integration: pyenv
+	pytest --cov=src/datajunction -vv tests/ --doctest-modules src/datajunction --with-integration --with-slow-integration
 
 clean:
 	pyenv virtualenv-delete datajunction

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,6 +84,7 @@ testing =
     pylint>=2.11.1
     pytest-asyncio==0.15.1
     pytest-cov>=2.12.1
+    pytest-integration==0.2.2
     pytest-mock>=3.6.1
     pytest>=6.2.5
     requests-mock>=1.9.3

--- a/tests/integration/basic_test.py
+++ b/tests/integration/basic_test.py
@@ -1,0 +1,23 @@
+"""
+Basic integration tests.
+"""
+
+import pytest
+from sqlalchemy.engine import create_engine
+
+
+@pytest.mark.integration_test
+def test_query() -> None:
+    """
+    Test a simple query.
+    """
+    engine = create_engine("dj://localhost:8000/0")
+    connection = engine.connect()
+
+    sql = """
+SELECT "core.users.gender", "core.num_comments"
+FROM metrics
+GROUP BY "core.users.gender"
+    """
+    results = list(connection.execute(sql))
+    assert results == [("female", 5), ("non-binary", 9), ("male", 7)]


### PR DESCRIPTION
Add a simple integration test. To run:

1. `docker compose up`
2. `make integration` (or `pytest --cov=src/datajunction -vv tests/ --doctest-modules src/datajunction --with-integration --with-slow-integration``)