### PR TITLE
Ping each database when evaluating candidates for query.

### DIFF
--- a/src/datajunction/models/database.py
+++ b/src/datajunction/models/database.py
@@ -8,11 +8,9 @@ from typing import TYPE_CHECKING, Dict, List, Optional, TypedDict
 
 from sqlalchemy import DateTime, String
 from sqlalchemy.sql.schema import Column as SqlaColumn
-from sqlmodel import JSON, Field, Relationship, SQLModel
+from sqlmodel import JSON, Field, Relationship, SQLModel, create_engine
 
 if TYPE_CHECKING:
-    from datajunction.models.column import Column
-    from datajunction.models.node import Node
     from datajunction.models.query import Query
     from datajunction.models.table import Table
 
@@ -48,6 +46,17 @@ class Database(SQLModel, table=True):  # type: ignore
     read_only: bool = True
     async_: bool = Field(default=False, sa_column_kwargs={"name": "async"})
     cost: float = 1.0
+
+    @property
+    def engine(self):
+        return create_engine(self.URI, **self.extra_params)
+
+    def ping(self):
+        try:
+            raw_connection = self.engine.raw_connection()
+            return self.engine.dialect.do_ping(raw_connection)
+        except:
+            return False
 
     created_at: datetime = Field(
         sa_column=SqlaColumn(DateTime(timezone=True)),

--- a/src/datajunction/sql/dag.py
+++ b/src/datajunction/sql/dag.py
@@ -118,13 +118,18 @@ def get_database_for_nodes(
     if not databases:
         raise Exception("No valid database was found")
 
+    active_databases = [db for db in databases if db.ping()]
+
+    if not active_databases:
+        raise Exception("No active database was found")
+
     if database_id is not None:
-        for database in databases:
+        for database in active_databases:
             if database.id == database_id:
                 return database
         raise Exception(f"Database ID {database_id} is not valid")
 
-    return sorted(databases, key=operator.attrgetter("cost"))[0]
+    return sorted(active_databases, key=operator.attrgetter("cost"))[0]
 
 
 def get_referenced_columns_from_sql(


### PR DESCRIPTION
### Summary
As per title, we now check if the database is active before returning it to the user as a potential query source. This prevents getting queries that can not be run at the moment.

### Test Plan
In my setup Druid db is broken, but defined as the lowes cost db, so I was getting an error before the fix. After this change I am getting a query from the next best db - Postgres.

### Deployment Plan
auto