### PR TITLE
chore: remove create_engine

### DIFF
--- a/src/datajunction/engine.py
+++ b/src/datajunction/engine.py
@@ -8,7 +8,7 @@ from typing import List, Tuple
 
 import sqlparse
 from sqlalchemy import text
-from sqlmodel import Session, create_engine
+from sqlmodel import Session
 
 from datajunction.config import Settings
 from datajunction.models.query import (
@@ -66,7 +66,7 @@ def run_query(query: Query) -> List[Tuple[str, List[ColumnMetadata], Stream]]:
     columns (name and type) and a stream of rows (tuples).
     """
     _logger.info("Running query on database %s", query.database.name)
-    engine = create_engine(query.database.URI, **query.database.extra_params)
+    engine = query.database.engine
     connection = engine.connect()
 
     output: List[Tuple[str, List[ColumnMetadata], Stream]] = []

--- a/src/datajunction/sql/transpile.py
+++ b/src/datajunction/sql/transpile.py
@@ -11,7 +11,6 @@ import operator
 from typing import Any, Dict, List, Optional, Set, Union, cast
 
 from sqlalchemy import case, desc, text
-from sqlalchemy.engine import create_engine
 from sqlalchemy.schema import Column as SqlaColumn
 from sqlalchemy.schema import MetaData, Table
 from sqlalchemy.sql import Select, select
@@ -75,7 +74,7 @@ def get_select_for_node(
     if columns is None:
         columns = {column.name for column in node.columns}
 
-    engine = create_engine(database.URI, **database.extra_params)
+    engine = database.engine
 
     # if the node is materialized we use the table with the cheapest cost, as long as it
     # has all the requested columns (see #104)

--- a/tests/sql/build_test.py
+++ b/tests/sql/build_test.py
@@ -50,7 +50,7 @@ def test_get_query_for_node(mocker: MockerFixture) -> None:
     engine = create_engine(database.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE B (cnt INTEGER)")
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
     session = mocker.MagicMock()
 
     create_query = get_query_for_node(session, child, [], [])
@@ -92,7 +92,7 @@ def test_get_query_for_node_with_groupbys(mocker: MockerFixture) -> None:
     engine = create_engine(database.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE A (user_id INTEGER, comment TEXT)")
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
     session = mocker.MagicMock()
 
     create_query = get_query_for_node(session, child, ["A.user_id"], [])
@@ -132,7 +132,7 @@ def test_get_query_for_node_specify_database(mocker: MockerFixture) -> None:
     engine = create_engine(database.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE B (cnt INTEGER)")
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
     session = mocker.MagicMock()
     session.exec().one.return_value = database
 
@@ -266,7 +266,7 @@ def test_get_query_for_node_with_dimensions(mocker: MockerFixture) -> None:
     connection = engine.connect()
     connection.execute("CREATE TABLE dim_users (id INTEGER, age INTEGER, gender TEXT)")
     connection.execute("CREATE TABLE comments (ds TEXT, user_id INTEGER, text TEXT)")
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
     session = mocker.MagicMock()
     session.exec().one.return_value = dimension
 
@@ -385,7 +385,7 @@ def test_get_query_for_node_with_multiple_dimensions(mocker: MockerFixture) -> N
     connection.execute(
         "CREATE TABLE comments (ds TEXT, user_id INTEGER, band_id INTEGER, text TEXT)",
     )
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
     session = mocker.MagicMock()
     session.exec().one.side_effect = [dimension_1, dimension_2]
 
@@ -495,7 +495,7 @@ def test_get_query_for_sql(mocker: MockerFixture, session: Session) -> None:
     engine = create_engine(database.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE A (one TEXT, two TEXT)")
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
 
     B = Node(
         name="B",
@@ -553,7 +553,7 @@ def test_get_query_for_sql_no_metrics(mocker: MockerFixture, session: Session) -
     engine = create_engine(database.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE dim_users (id INTEGER, age INTEGER, gender TEXT)")
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
 
     session.add(dimension)
     session.commit()
@@ -634,7 +634,7 @@ def test_get_query_for_sql_having(mocker: MockerFixture, session: Session) -> No
     engine = create_engine(database.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE A (one TEXT, two TEXT)")
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
 
     B = Node(
         name="B",
@@ -729,7 +729,7 @@ def test_get_query_for_sql_with_dimensions(
     connection = engine.connect()
     connection.execute("CREATE TABLE dim_users (id INTEGER, age INTEGER, gender TEXT)")
     connection.execute("CREATE TABLE comments (ds TEXT, user_id INTEGER, text TEXT)")
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
 
     session.add(child)
     session.add(dimension)
@@ -830,7 +830,7 @@ def test_get_query_for_sql_with_dimensions_order_by(
     connection = engine.connect()
     connection.execute("CREATE TABLE dim_users (id INTEGER, age INTEGER, gender TEXT)")
     connection.execute("CREATE TABLE comments (ds TEXT, user_id INTEGER, text TEXT)")
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
 
     session.add(child)
     session.add(dimension)
@@ -956,7 +956,7 @@ def test_get_query_for_sql_compound_names(
     engine = create_engine(database.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE A (one TEXT, two TEXT)")
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
 
     B = Node(
         name="core.B",
@@ -1022,7 +1022,7 @@ def test_get_query_for_sql_multiple_databases(
     engine = create_engine(database_1.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE A (one TEXT, two TEXT)")
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
 
     B = Node(
         name="B",
@@ -1081,7 +1081,7 @@ def test_get_query_for_sql_multiple_metrics(
     engine = create_engine(database.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE A (one TEXT, two TEXT)")
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
 
     B = Node(
         name="B",
@@ -1146,7 +1146,7 @@ def test_get_query_for_sql_non_identifiers(
     engine = create_engine(database.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE A (one TEXT, two TEXT)")
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
 
     B = Node(
         name="B",
@@ -1331,7 +1331,7 @@ def test_get_query_for_sql_alias(mocker: MockerFixture, session: Session) -> Non
     engine = create_engine(database.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE A (one TEXT, two TEXT)")
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
 
     B = Node(
         name="B",
@@ -1385,7 +1385,7 @@ def test_get_query_for_sql_where_groupby(
     engine = create_engine(database.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE comments (user_id INT, comment TEXT)")
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
 
     num_comments = Node(
         name="core.num_comments",
@@ -1444,7 +1444,7 @@ def test_get_query_for_sql_date_trunc(
     engine = create_engine(database.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE comments (user_id INT, timestamp DATETIME)")
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
 
     num_comments = Node(
         name="core.num_comments",
@@ -1505,7 +1505,7 @@ def test_get_query_for_sql_invalid_column(
     engine = create_engine(database.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE comments (user_id INT, comment TEXT)")
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
 
     num_comments = Node(
         name="core.num_comments",

--- a/tests/sql/transpile_test.py
+++ b/tests/sql/transpile_test.py
@@ -53,7 +53,7 @@ def test_get_select_for_node_materialized(mocker: MockerFixture) -> None:
     engine = create_engine(database.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE B (cnt INTEGER)")
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
 
     assert (
         query_to_string(get_select_for_node(child, database))
@@ -92,7 +92,7 @@ def test_get_select_for_node_not_materialized(mocker: MockerFixture) -> None:
     connection = engine.connect()
     connection.execute("CREATE TABLE A_slow (one TEXT, two TEXT)")
     connection.execute("CREATE TABLE A_fast (one TEXT)")
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
 
     child = Node(
         name="B",
@@ -155,7 +155,7 @@ def test_get_select_for_node_choose_slow(mocker: MockerFixture) -> None:
     connection = engine.connect()
     connection.execute("CREATE TABLE A_slow (one TEXT, two TEXT)")
     connection.execute("CREATE TABLE A_fast (one TEXT)")
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
 
     child = Node(
         name="B",
@@ -201,7 +201,7 @@ def test_get_select_for_node_projection(mocker: MockerFixture) -> None:
     engine = create_engine(database.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE A (one TEXT, two TEXT)")
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
 
     child = Node(
         name="B",
@@ -246,7 +246,7 @@ def test_get_select_for_node_where(mocker: MockerFixture) -> None:
     engine = create_engine(database.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE A (one TEXT, two TEXT)")
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
 
     child = Node(
         name="B",
@@ -292,7 +292,7 @@ def test_get_select_for_node_groupby(mocker: MockerFixture) -> None:
     engine = create_engine(database.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE A (one TEXT, two TEXT)")
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
 
     child = Node(
         name="B",
@@ -337,7 +337,7 @@ def test_get_select_for_node_limit(mocker: MockerFixture) -> None:
     engine = create_engine(database.URI)
     connection = engine.connect()
     connection.execute("CREATE TABLE A (one TEXT, two TEXT)")
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
 
     child = Node(
         name="B",
@@ -441,7 +441,7 @@ def test_get_select_for_node_with_join(mocker: MockerFixture) -> None:
     connection = engine.connect()
     connection.execute("CREATE TABLE A (one TEXT, two TEXT)")
     connection.execute("CREATE TABLE B (two TEXT, three TEXT)")
-    mocker.patch("datajunction.sql.transpile.create_engine", return_value=engine)
+    mocker.patch("datajunction.models.database.create_engine", return_value=engine)
 
     child = Node(
         name="B",


### PR DESCRIPTION
Use the `Database.engine` property introduced in https://github.com/DataJunction/datajunction/pull/168.