### PR TITLE
refactor: dimension nodes have expressions

### DIFF
--- a/examples/configs/nodes/core/dim_users.yaml
+++ b/examples/configs/nodes/core/dim_users.yaml
@@ -1,0 +1,18 @@
+description: User dimension
+type: dimension
+expression: SELECT * FROM core.users
+columns:
+  id:
+    type: INT
+  full_name:
+    type: STR
+  age:
+    type: INT
+  country:
+    type: STR
+  gender:
+    type: STR
+  preferred_language:
+    type: STR
+  secret_number:
+    type: FLOAT

--- a/examples/configs/nodes/core/users.yaml
+++ b/examples/configs/nodes/core/users.yaml
@@ -1,5 +1,5 @@
-description: A user dimension table
-type: dimension
+description: A user table
+type: source
 columns:
   id:
     type: INT

--- a/src/datajunction/models/node.py
+++ b/src/datajunction/models/node.py
@@ -165,20 +165,20 @@ class Node(SQLModel, table=True):  # type: ignore
     def extra_validation(self) -> None:
         """
         Extra validation for node data.
-
-        This checks that node marked as source/dimension have tables associated with them, and
-        that metric nodes have a valid expression.
         """
-        if self.type in {NodeType.SOURCE.value, NodeType.DIMENSION.value}:
+        if self.type == NodeType.SOURCE:
             if not self.tables:
                 raise Exception(
-                    f"Node {self.name} of type {self.type} needs at least one table",
+                    f"Node {self.name} of type source needs at least one table",
                 )
-        elif self.type == NodeType.METRIC:
+
+        if self.type in {NodeType.TRANSFORM, NodeType.METRIC, NodeType.DIMENSION}:
             if not self.expression:
                 raise Exception(
-                    f"Node {self.name} of type metric needs an expression",
+                    f"Node {self.name} of type {self.type} needs an expression",
                 )
+
+        if self.type == NodeType.METRIC:
             if not is_metric(self.expression):
                 raise Exception(
                     f"Node {self.name} of type metric has an invalid expression, "

--- a/src/datajunction/sql/inference.py
+++ b/src/datajunction/sql/inference.py
@@ -38,13 +38,17 @@ def infer_columns(sql: str, parents: List["Node"]) -> List[Column]:
         alias: Optional[str] = None
         if "UnnamedExpr" in expression:
             expression = expression["UnnamedExpr"]
+            columns.append(get_column_from_expression(parents, expression, alias))
         elif "ExprWithAlias" in expression:
             alias = expression["ExprWithAlias"]["alias"]["value"]
             expression = expression["ExprWithAlias"]["expr"]
+            columns.append(get_column_from_expression(parents, expression, alias))
+        elif expression == "Wildcard":
+            if len(parents) > 1:
+                raise Exception("Wildcard only works for nodes with a single parent")
+            columns.extend(parents[0].columns[:])
         else:
             raise NotImplementedError(f"Unable to handle expression: {expression}")
-
-        columns.append(get_column_from_expression(parents, expression, alias))
 
     # name nameless columns
     i = 0

--- a/src/datajunction/sql/parse.py
+++ b/src/datajunction/sql/parse.py
@@ -2,7 +2,7 @@
 SQL parsing functions.
 """
 
-from typing import Any, Iterator, Set, Tuple
+from typing import Any, Iterator, Optional, Set, Tuple
 
 from sqloxide import parse_sql
 
@@ -60,13 +60,16 @@ def get_expression_from_projection(projection: Projection) -> Expression:
     raise NotImplementedError(f"Unable to handle expression: {projection}")
 
 
-def is_metric(sql: str) -> bool:
+def is_metric(sql: Optional[str]) -> bool:
     """
     Return if a SQL expression defines a metric.
 
     The SQL expression should have a single expression in its projections, and it should
     be an aggregation function in order for it to be considered a metric.
     """
+    if sql is None:
+        return False
+
     tree = parse_sql(sql, dialect="ansi")
     projection = next(find_nodes_by_key(tree, "projection"))
 

--- a/tests/cli/compile_test.py
+++ b/tests/cli/compile_test.py
@@ -257,6 +257,14 @@ async def test_index_nodes(
             "expression": None,
         },
         {
+            "name": "core.dim_users",
+            "description": "User dimension",
+            "type": NodeType.DIMENSION,
+            "created_at": datetime(2021, 1, 2, 0, 0),
+            "updated_at": datetime(2021, 1, 2, 0, 0),
+            "expression": "SELECT * FROM core.users",
+        },
+        {
             "name": "core.num_comments",
             "description": "Number of comments",
             "type": NodeType.METRIC,
@@ -266,8 +274,8 @@ async def test_index_nodes(
         },
         {
             "name": "core.users",
-            "description": "A user dimension table",
-            "type": NodeType.DIMENSION,
+            "description": "A user table",
+            "type": NodeType.SOURCE,
             "created_at": datetime(2021, 1, 2, 0, 0),
             "updated_at": datetime(2021, 1, 2, 0, 0),
             "expression": None,
@@ -282,6 +290,7 @@ async def test_index_nodes(
 
     assert [(node.name, node.updated_at) for node in nodes] == [
         ("core.comments", datetime(2021, 1, 2, 0, 0)),
+        ("core.dim_users", datetime(2021, 1, 3, 0, 0)),
         ("core.num_comments", datetime(2021, 1, 3, 0, 0)),
         ("core.users", datetime(2021, 1, 3, 0, 0)),
     ]
@@ -294,6 +303,7 @@ async def test_index_nodes(
 
     assert [(node.name, node.updated_at) for node in nodes] == [
         ("core.comments", datetime(2021, 1, 2, 0, 0)),
+        ("core.dim_users", datetime(2021, 1, 3, 0, 0)),
         ("core.num_comments", datetime(2021, 1, 3, 0, 0)),
         ("core.users", datetime(2021, 1, 3, 0, 0)),
     ]

--- a/tests/models/node_test.py
+++ b/tests/models/node_test.py
@@ -50,5 +50,11 @@ def test_extra_validation() -> None:
         "Node A of type metric has an invalid expression, "
         "should have a single aggregation"
     )
-    node = Node(name="A", type=NodeType.TRANSFORM)
+
+    node = Node(name="A", type=NodeType.TRANSFORM, expression="SELECT * FROM B")
     node.extra_validation()
+
+    node = Node(name="A", type=NodeType.TRANSFORM)
+    with pytest.raises(Exception) as excinfo:
+        node.extra_validation()
+    assert str(excinfo.value) == "Node A of type transform needs an expression"

--- a/tests/sql/inference_test.py
+++ b/tests/sql/inference_test.py
@@ -260,10 +260,17 @@ def test_infer_columns() -> None:
 
     assert infer_columns("SELECT COUNT(*) AS cnt FROM A", [parent]) == [
         Column(
-            id=None,
             name="cnt",
             type=ColumnType.INT,
-            dimension_id=None,
-            dimension_column=None,
         ),
     ]
+
+    assert infer_columns("SELECT * FROM A", [parent]) == [
+        Column(name="ds", type=ColumnType.STR),
+        Column(name="user_id", type=ColumnType.INT),
+        Column(name="foo", type=ColumnType.FLOAT),
+    ]
+
+    with pytest.raises(Exception) as excinfo:
+        infer_columns("SELECT * FROM A", [parent, parent])
+    assert str(excinfo.value) == "Wildcard only works for nodes with a single parent"

--- a/tests/sql/parse_test.py
+++ b/tests/sql/parse_test.py
@@ -13,3 +13,4 @@ def test_is_metric() -> None:
     assert is_metric("SELECT COUNT(*) AS cnt FROM my_table")
     assert not is_metric("SELECT COUNT(*), SUM(cnt) FROM my_table")
     assert not is_metric("SELECT 42 FROM my_table")
+    assert not is_metric(None)


### PR DESCRIPTION
Change dimension nodes so they must have an `expression`, making them more similar to transform nodes than source nodes.