### PR TITLE
chore: rename `node.expression` to `node.query`

### DIFF
--- a/ARCHITECTURE.rst
+++ b/ARCHITECTURE.rst
@@ -2,7 +2,7 @@
 Architecture
 ============
 
-The source of truth in DataJunction (DJ) is a repository of YAML files (see the `examples <https://github.com/DataJunction/datajunction/tree/main/examples/configs>`_). These files describe database connections and nodes. The nodes form a DAG (Directed Acyclic Graph), and relationships are inferred from their SQL expressions:
+The source of truth in DataJunction (DJ) is a repository of YAML files (see the `examples <https://github.com/DataJunction/datajunction/tree/main/examples/configs>`_). These files describe database connections and nodes. The nodes form a DAG (Directed Acyclic Graph), and relationships are inferred from their SQL queries:
 
 .. code-block:: YAML
 
@@ -18,7 +18,7 @@ The source of truth in DataJunction (DJ) is a repository of YAML files (see the 
 
     # child.yaml
     description: A child node
-    expression: SELECT * FROM parent
+    query: SELECT * FROM parent
 
 In the example above we have 2 nodes, ``parent`` and ``child``, forming the DAG ``parent -> child``.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -146,7 +146,7 @@ To see the list of available nodes:
         "created_at": "2022-04-10T20:22:58.345198",
         "updated_at": "2022-04-10T20:22:58.345201",
         "type": "source",
-        "expression": null,
+        "query": null,
         "columns": [
           {
             "name": "id",
@@ -181,7 +181,7 @@ To see the list of available nodes:
         "created_at": "2022-04-10T20:23:01.333020",
         "updated_at": "2022-04-10T20:23:01.333024",
         "type": "dimension",
-        "expression": null,
+        "query": null,
         "columns": [
           {
             "name": "id",
@@ -220,7 +220,7 @@ To see the list of available nodes:
         "created_at": "2022-04-10T20:23:01.961078",
         "updated_at": "2022-04-10T20:23:01.961083",
         "type": "metric",
-        "expression": "SELECT COUNT(*) FROM core.comments",
+        "query": "SELECT COUNT(*) FROM core.comments",
         "columns": [
           {
             "name": "_col0",
@@ -242,7 +242,7 @@ And metrics:
         "description": "Number of comments",
         "created_at": "2022-04-10T20:23:01.961078",
         "updated_at": "2022-04-10T20:23:01.961083",
-        "expression": "SELECT COUNT(*) FROM core.comments",
+        "query": "SELECT COUNT(*) FROM core.comments",
         "dimensions": [
           "core.comments.id",
           "core.comments.user_id",

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ So far we've only described what already exists. Let's add a metric called ``num
     # nodes/num_comments.yaml
     type: metric
     description: The number of comments
-    expression: SELECT COUNT(*) FROM comments
+    query: SELECT COUNT(*) FROM comments
 
 Now we run a command to parse all the configuration files and index them in a database:
 
@@ -93,7 +93,7 @@ We can also filter and group our metric by any of its dimensions:
       "description": "A fact table with comments",
       "created_at": "2022-01-17T19:06:09.215689",
       "updated_at": "2022-04-04T16:27:53.374001",
-      "expression": "SELECT COUNT(*) FROM comments",
+      "query": "SELECT COUNT(*) FROM comments",
       "dimensions": [
         "comments.id",
         "comments.user_id",

--- a/alembic/versions/2022_09_02_1928-37cd6f86330a_rename_expression_to_query_in_nodes.py
+++ b/alembic/versions/2022_09_02_1928-37cd6f86330a_rename_expression_to_query_in_nodes.py
@@ -1,0 +1,33 @@
+"""Rename expression to query in nodes
+
+Revision ID: 37cd6f86330a
+Revises: 7f8367fdfa30
+Create Date: 2022-09-02 19:28:11.904941+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import
+
+import sqlalchemy as sa
+import sqlmodel
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "37cd6f86330a"
+down_revision = "7f8367fdfa30"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_index("ix_node_expression", table_name="node")
+    with op.batch_alter_table("node") as bop:
+        bop.alter_column("expression", new_column_name="query")
+    op.create_index(op.f("ix_node_query"), "node", ["query"], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f("ix_node_query"), table_name="node")
+    with op.batch_alter_table("node") as bop:
+        bop.alter_column("query", new_column_name="expression")
+    op.create_index("ix_node_expression", "node", ["expression"], unique=False)

--- a/examples/configs/nodes/core/dim_users.yaml
+++ b/examples/configs/nodes/core/dim_users.yaml
@@ -1,6 +1,6 @@
 description: User dimension
 type: dimension
-expression: SELECT * FROM core.users
+query: SELECT * FROM core.users
 columns:
   id:
     type: INT

--- a/examples/configs/nodes/core/num_comments.yaml
+++ b/examples/configs/nodes/core/num_comments.yaml
@@ -1,6 +1,6 @@
 description: Number of comments
 type: metric
-expression: SELECT COUNT(*) FROM core.comments
+query: SELECT COUNT(*) FROM core.comments
 columns:
   _col0:
     type: INT

--- a/src/datajunction/api/metrics.py
+++ b/src/datajunction/api/metrics.py
@@ -32,7 +32,7 @@ class Metric(SQLModel):
     created_at: datetime
     updated_at: datetime
 
-    expression: str
+    query: str
 
     dimensions: List[str]
 

--- a/src/datajunction/api/nodes.py
+++ b/src/datajunction/api/nodes.py
@@ -39,7 +39,7 @@ class NodeMetadata(SQLModel):
     updated_at: datetime
 
     type: NodeType
-    expression: Optional[str] = None
+    query: Optional[str] = None
 
     columns: List[SimpleColumn]
 

--- a/src/datajunction/cli/compile.py
+++ b/src/datajunction/cli/compile.py
@@ -250,8 +250,8 @@ async def index_nodes(  # pylint: disable=too-many-locals
     configs = await load_node_configs(repository)
     dependencies: Dict[str, Set[str]] = {}
     for config in configs:
-        if "expression" in config:
-            dependencies[config["name"]] = get_dependencies(config["expression"])
+        if "query" in config:
+            dependencies[config["name"]] = get_dependencies(config["query"])
         else:
             dependencies[config["name"]] = set()
         # add dimensions to dependencies
@@ -334,7 +334,7 @@ async def add_node(  # pylint: disable=too-many-locals
         "created_at": node.created_at if node else datetime.now(timezone.utc),
         "updated_at": datetime.now(timezone.utc),
         "type": data["type"],
-        "expression": data.get("expression"),
+        "query": data.get("query"),
         "tables": [],
         "parents": parents,
     }
@@ -356,8 +356,8 @@ async def add_node(  # pylint: disable=too-many-locals
             )
 
     config["columns"] = (
-        infer_columns(data["expression"], parents)
-        if data.get("expression")
+        infer_columns(data["query"], parents)
+        if data.get("query")
         else get_columns_from_tables(config["tables"])
     )
 

--- a/src/datajunction/sql/dag.py
+++ b/src/datajunction/sql/dag.py
@@ -73,7 +73,7 @@ def get_computable_databases(
     """
     Return all the databases where a given node can be computed.
 
-    This takes into consideration the node expression, since some of the columns might
+    This takes into consideration the node query, since some of the columns might
     not be present in all databases.
     """
     if columns is None:
@@ -88,7 +88,7 @@ def get_computable_databases(
     databases = {table.database for table in tables}
 
     # add all the databases that are common between the parents and match all the columns
-    parent_columns = get_referenced_columns_from_sql(node.expression, node.parents)
+    parent_columns = get_referenced_columns_from_sql(node.query, node.parents)
     if node.parents:
         parent_databases = [
             get_computable_databases(parent, parent_columns[parent.name])
@@ -180,18 +180,18 @@ async def get_cheapest_online_database(databases: Set[Database]) -> Database:
 
 
 def get_referenced_columns_from_sql(
-    sql: Optional[str],
+    query: Optional[str],
     parents: List[Node],
 ) -> DefaultDict[str, Set[str]]:
     """
-    Given a SQL expression, return the referenced columns.
+    Given a SQL query, return the referenced columns.
 
     Referenced columns are a dictionary mapping parent name to column name(s).
     """
-    if not sql:
+    if not query:
         return defaultdict(set)
 
-    tree = parse_sql(sql, dialect="ansi")
+    tree = parse_sql(query, dialect="ansi")
 
     return get_referenced_columns_from_tree(tree, parents)
 

--- a/src/datajunction/sql/inference.py
+++ b/src/datajunction/sql/inference.py
@@ -19,15 +19,15 @@ if TYPE_CHECKING:
 
 class Wildcard:  # pylint: disable=too-few-public-methods
     """
-    Represents the star in a SQL expression.
+    Represents the star in a SQL query.
     """
 
 
-def infer_columns(sql: str, parents: List["Node"]) -> List[Column]:
+def infer_columns(query: str, parents: List["Node"]) -> List[Column]:
     """
-    Given a a SQL expression and parents, infer schema.
+    Given a a SQL query and parents, infer schema.
     """
-    tree = parse_sql(sql, dialect="ansi")
+    tree = parse_sql(query, dialect="ansi")
 
     # Use the first projection. We actually want to check that all the projections
     # produce the same columns, and raise an error if not.

--- a/src/datajunction/sql/parse.py
+++ b/src/datajunction/sql/parse.py
@@ -36,11 +36,11 @@ def find_nodes_by_key_with_parent(
                 yield from find_nodes_by_key_with_parent(value, target)
 
 
-def get_dependencies(sql: str) -> Set[str]:
+def get_dependencies(query: str) -> Set[str]:
     """
-    Return all the dependencies from a SQL expression.
+    Return all the dependencies from a SQL query.
     """
-    tree = parse_sql(sql, dialect="ansi")
+    tree = parse_sql(query, dialect="ansi")
 
     return {
         ".".join(part["value"] for part in table["name"])
@@ -60,17 +60,17 @@ def get_expression_from_projection(projection: Projection) -> Expression:
     raise NotImplementedError(f"Unable to handle expression: {projection}")
 
 
-def is_metric(sql: Optional[str]) -> bool:
+def is_metric(query: Optional[str]) -> bool:
     """
-    Return if a SQL expression defines a metric.
+    Return if a SQL query defines a metric.
 
-    The SQL expression should have a single expression in its projections, and it should
+    The SQL query should have a single expression in its projections, and it should
     be an aggregation function in order for it to be considered a metric.
     """
-    if sql is None:
+    if query is None:
         return False
 
-    tree = parse_sql(sql, dialect="ansi")
+    tree = parse_sql(query, dialect="ansi")
     projection = next(find_nodes_by_key(tree, "projection"))
 
     # must have a single expression

--- a/tests/api/metrics_test.py
+++ b/tests/api/metrics_test.py
@@ -21,10 +21,10 @@ def test_read_metrics(session: Session, client: TestClient) -> None:
     Test ``GET /metrics/``.
     """
     node1 = Node(name="not-a-metric")
-    node2 = Node(name="also-not-a-metric", expression="SELECT 42")
+    node2 = Node(name="also-not-a-metric", query="SELECT 42")
     node3 = Node(
         name="a-metric",
-        expression="SELECT COUNT(*) FROM my_table",
+        query="SELECT COUNT(*) FROM my_table",
         type=NodeType.METRIC,
     )
     session.add(node1)
@@ -38,7 +38,7 @@ def test_read_metrics(session: Session, client: TestClient) -> None:
     assert response.status_code == 200
     assert len(data) == 1
     assert data[0]["name"] == "a-metric"
-    assert data[0]["expression"] == "SELECT COUNT(*) FROM my_table"
+    assert data[0]["query"] == "SELECT COUNT(*) FROM my_table"
 
 
 def test_read_metric(session: Session, client: TestClient) -> None:
@@ -67,7 +67,7 @@ def test_read_metric(session: Session, client: TestClient) -> None:
 
     child = Node(
         name="child",
-        expression="SELECT COUNT(*) FROM parent",
+        query="SELECT COUNT(*) FROM parent",
         parents=[parent],
         type=NodeType.METRIC,
     )
@@ -80,7 +80,7 @@ def test_read_metric(session: Session, client: TestClient) -> None:
 
     assert response.status_code == 200
     assert data["name"] == "child"
-    assert data["expression"] == "SELECT COUNT(*) FROM parent"
+    assert data["query"] == "SELECT COUNT(*) FROM parent"
     assert data["dimensions"] == ["parent.ds", "parent.foo", "parent.user_id"]
 
 
@@ -95,7 +95,7 @@ def test_read_metrics_data(
     database = Database(name="test", URI="sqlite://")
     node = Node(
         name="a-metric",
-        expression="SELECT COUNT(*) FROM my_table",
+        query="SELECT COUNT(*) FROM my_table",
         type=NodeType.METRIC,
     )
     session.add(database)
@@ -135,7 +135,7 @@ def test_read_metrics_data_errors(session: Session, client: TestClient) -> None:
     Test errors on ``GET /metrics/{node_id}/data/``.
     """
     database = Database(name="test", URI="sqlite://")
-    node = Node(name="a-metric", expression="SELECT 1 AS col")
+    node = Node(name="a-metric", query="SELECT 1 AS col")
     session.add(database)
     session.add(node)
     session.execute("CREATE TABLE my_table (one TEXT)")
@@ -161,7 +161,7 @@ def test_read_metrics_sql(
     database = Database(name="test", URI="sqlite://")
     node = Node(
         name="a-metric",
-        expression="SELECT COUNT(*) FROM my_table",
+        query="SELECT COUNT(*) FROM my_table",
         type=NodeType.METRIC,
     )
     session.add(database)

--- a/tests/api/nodes_test.py
+++ b/tests/api/nodes_test.py
@@ -16,7 +16,7 @@ def test_read_nodes(session: Session, client: TestClient) -> None:
     node1 = Node(name="not-a-metric", type=NodeType.SOURCE)
     node2 = Node(
         name="also-not-a-metric",
-        expression="SELECT 42 AS answer",
+        query="SELECT 42 AS answer",
         type=NodeType.TRANSFORM,
         columns=[
             Column(name="answer", type=ColumnType.INT),
@@ -24,7 +24,7 @@ def test_read_nodes(session: Session, client: TestClient) -> None:
     )
     node3 = Node(
         name="a-metric",
-        expression="SELECT COUNT(*) FROM my_table",
+        query="SELECT COUNT(*) FROM my_table",
         columns=[
             Column(name="_col0", type=ColumnType.INT),
         ],
@@ -43,10 +43,10 @@ def test_read_nodes(session: Session, client: TestClient) -> None:
 
     nodes = {node["name"]: node for node in data}
 
-    assert nodes["not-a-metric"]["expression"] is None
+    assert nodes["not-a-metric"]["query"] is None
     assert not nodes["not-a-metric"]["columns"]
 
-    assert nodes["also-not-a-metric"]["expression"] == "SELECT 42 AS answer"
+    assert nodes["also-not-a-metric"]["query"] == "SELECT 42 AS answer"
     assert nodes["also-not-a-metric"]["columns"] == [
         {
             "name": "answer",
@@ -54,7 +54,7 @@ def test_read_nodes(session: Session, client: TestClient) -> None:
         },
     ]
 
-    assert nodes["a-metric"]["expression"] == "SELECT COUNT(*) FROM my_table"
+    assert nodes["a-metric"]["query"] == "SELECT COUNT(*) FROM my_table"
     assert nodes["a-metric"]["columns"] == [
         {
             "name": "_col0",

--- a/tests/cli/compile_test.py
+++ b/tests/cli/compile_test.py
@@ -254,7 +254,7 @@ async def test_index_nodes(
             "type": NodeType.SOURCE,
             "created_at": datetime(2021, 1, 2, 0, 0),
             "updated_at": datetime(2021, 1, 2, 0, 0),
-            "expression": None,
+            "query": None,
         },
         {
             "name": "core.dim_users",
@@ -262,7 +262,7 @@ async def test_index_nodes(
             "type": NodeType.DIMENSION,
             "created_at": datetime(2021, 1, 2, 0, 0),
             "updated_at": datetime(2021, 1, 2, 0, 0),
-            "expression": "SELECT * FROM core.users",
+            "query": "SELECT * FROM core.users",
         },
         {
             "name": "core.num_comments",
@@ -270,7 +270,7 @@ async def test_index_nodes(
             "type": NodeType.METRIC,
             "created_at": datetime(2021, 1, 2, 0, 0),
             "updated_at": datetime(2021, 1, 2, 0, 0),
-            "expression": "SELECT COUNT(*) FROM core.comments",
+            "query": "SELECT COUNT(*) FROM core.comments",
         },
         {
             "name": "core.users",
@@ -278,7 +278,7 @@ async def test_index_nodes(
             "type": NodeType.SOURCE,
             "created_at": datetime(2021, 1, 2, 0, 0),
             "updated_at": datetime(2021, 1, 2, 0, 0),
-            "expression": None,
+            "query": None,
         },
     ]
 

--- a/tests/models/node_test.py
+++ b/tests/models/node_test.py
@@ -41,20 +41,20 @@ def test_extra_validation() -> None:
     node = Node(name="A", type=NodeType.METRIC)
     with pytest.raises(Exception) as excinfo:
         node.extra_validation()
-    assert str(excinfo.value) == "Node A of type metric needs an expression"
+    assert str(excinfo.value) == "Node A of type metric needs a query"
 
-    node = Node(name="A", type=NodeType.METRIC, expression="SELECT 42")
+    node = Node(name="A", type=NodeType.METRIC, query="SELECT 42")
     with pytest.raises(Exception) as excinfo:
         node.extra_validation()
     assert str(excinfo.value) == (
-        "Node A of type metric has an invalid expression, "
+        "Node A of type metric has an invalid query, "
         "should have a single aggregation"
     )
 
-    node = Node(name="A", type=NodeType.TRANSFORM, expression="SELECT * FROM B")
+    node = Node(name="A", type=NodeType.TRANSFORM, query="SELECT * FROM B")
     node.extra_validation()
 
     node = Node(name="A", type=NodeType.TRANSFORM)
     with pytest.raises(Exception) as excinfo:
         node.extra_validation()
-    assert str(excinfo.value) == "Node A of type transform needs an expression"
+    assert str(excinfo.value) == "Node A of type transform needs a query"

--- a/tests/sql/build_test.py
+++ b/tests/sql/build_test.py
@@ -44,7 +44,7 @@ async def test_get_query_for_node(mocker: MockerFixture) -> None:
             ),
         ],
         type=NodeType.METRIC,
-        expression="SELECT COUNT(*) AS cnt FROM A",
+        query="SELECT COUNT(*) AS cnt FROM A",
         parents=[parent],
     )
 
@@ -87,7 +87,7 @@ async def test_get_query_for_node_with_groupbys(mocker: MockerFixture) -> None:
     child = Node(
         name="B",
         type=NodeType.METRIC,
-        expression="SELECT COUNT(*) AS cnt FROM A",
+        query="SELECT COUNT(*) AS cnt FROM A",
         parents=[parent],
     )
 
@@ -127,7 +127,7 @@ async def test_get_query_for_node_specify_database(mocker: MockerFixture) -> Non
             ),
         ],
         type=NodeType.METRIC,
-        expression="SELECT COUNT(*) AS cnt FROM A",
+        query="SELECT COUNT(*) AS cnt FROM A",
         parents=[parent],
         columns=[Column(name="cnt", type=ColumnType.INT)],
     )
@@ -167,7 +167,7 @@ async def test_get_query_for_node_no_databases(mocker: MockerFixture) -> None:
             ),
         ],
         type=NodeType.METRIC,
-        expression="SELECT COUNT(*) AS cnt FROM A",
+        query="SELECT COUNT(*) AS cnt FROM A",
         parents=[parent],
         columns=[Column(name="one", type=ColumnType.STR)],
     )
@@ -200,7 +200,7 @@ async def test_get_query_for_node_no_active_databases(mocker: MockerFixture) -> 
             ),
         ],
         type=NodeType.METRIC,
-        expression="SELECT COUNT(*) AS cnt FROM A",
+        query="SELECT COUNT(*) AS cnt FROM A",
         parents=[parent],
         columns=[Column(name="one", type=ColumnType.STR)],
     )
@@ -264,7 +264,7 @@ async def test_get_query_for_node_with_dimensions(mocker: MockerFixture) -> None
     child = Node(
         name="core.num_comments",
         type=NodeType.METRIC,
-        expression="SELECT COUNT(*) FROM core.comments",
+        query="SELECT COUNT(*) FROM core.comments",
         parents=[parent],
     )
 
@@ -383,7 +383,7 @@ async def test_get_query_for_node_with_multiple_dimensions(
     child = Node(
         name="core.num_comments",
         type=NodeType.METRIC,
-        expression="SELECT COUNT(*) FROM core.comments",
+        query="SELECT COUNT(*) FROM core.comments",
         parents=[parent],
     )
 
@@ -510,7 +510,7 @@ async def test_get_query_for_sql(mocker: MockerFixture, session: Session) -> Non
     B = Node(
         name="B",
         type=NodeType.METRIC,
-        expression="SELECT COUNT(*) AS cnt FROM A",
+        query="SELECT COUNT(*) AS cnt FROM A",
         parents=[A],
     )
     session.add(B)
@@ -661,7 +661,7 @@ async def test_get_query_for_sql_having(
     B = Node(
         name="B",
         type=NodeType.METRIC,
-        expression="SELECT COUNT(*) AS cnt FROM A",
+        query="SELECT COUNT(*) AS cnt FROM A",
         parents=[A],
     )
     session.add(B)
@@ -744,7 +744,7 @@ async def test_get_query_for_sql_with_dimensions(
     child = Node(
         name="core.num_comments",
         type=NodeType.METRIC,
-        expression="SELECT COUNT(*) FROM core.comments",
+        query="SELECT COUNT(*) FROM core.comments",
         parents=[parent],
     )
 
@@ -846,7 +846,7 @@ async def test_get_query_for_sql_with_dimensions_order_by(
     child = Node(
         name="core.num_comments",
         type=NodeType.METRIC,
-        expression="SELECT COUNT(*) FROM core.comments",
+        query="SELECT COUNT(*) FROM core.comments",
         parents=[parent],
     )
 
@@ -986,7 +986,7 @@ async def test_get_query_for_sql_compound_names(
     B = Node(
         name="core.B",
         type=NodeType.METRIC,
-        expression="SELECT COUNT(*) AS cnt FROM core.A",
+        query="SELECT COUNT(*) AS cnt FROM core.A",
         parents=[A],
     )
     session.add(B)
@@ -1053,7 +1053,7 @@ async def test_get_query_for_sql_multiple_databases(
     B = Node(
         name="B",
         type=NodeType.METRIC,
-        expression="SELECT COUNT(*) AS cnt FROM A",
+        query="SELECT COUNT(*) AS cnt FROM A",
         parents=[A],
     )
     session.add(B)
@@ -1064,7 +1064,7 @@ async def test_get_query_for_sql_multiple_databases(
 
     assert create_query.database_id == 2  # fast
 
-    B.expression = "SELECT COUNT(two) AS cnt FROM A"
+    B.query = "SELECT COUNT(two) AS cnt FROM A"
     session.add(B)
     session.commit()
 
@@ -1113,14 +1113,14 @@ async def test_get_query_for_sql_multiple_metrics(
     B = Node(
         name="B",
         type=NodeType.METRIC,
-        expression="SELECT COUNT(*) AS cnt FROM A",
+        query="SELECT COUNT(*) AS cnt FROM A",
         parents=[A],
     )
     session.add(B)
     C = Node(
         name="C",
         type=NodeType.METRIC,
-        expression="SELECT MAX(one) AS max_one FROM A",
+        query="SELECT MAX(one) AS max_one FROM A",
         parents=[A],
     )
     session.add(C)
@@ -1179,14 +1179,14 @@ async def test_get_query_for_sql_non_identifiers(
     B = Node(
         name="B",
         type=NodeType.METRIC,
-        expression="SELECT COUNT(*) AS cnt FROM A",
+        query="SELECT COUNT(*) AS cnt FROM A",
         parents=[A],
     )
     session.add(B)
     C = Node(
         name="C",
         type=NodeType.METRIC,
-        expression="SELECT MAX(one) AS max_one FROM A",
+        query="SELECT MAX(one) AS max_one FROM A",
         parents=[A],
     )
     session.add(C)
@@ -1248,14 +1248,14 @@ async def test_get_query_for_sql_different_parents(
     C = Node(
         name="C",
         type=NodeType.METRIC,
-        expression="SELECT COUNT(*) AS cnt FROM A",
+        query="SELECT COUNT(*) AS cnt FROM A",
         parents=[A],
     )
     session.add(C)
     D = Node(
         name="D",
         type=NodeType.METRIC,
-        expression="SELECT MAX(one) AS max_one FROM A",
+        query="SELECT MAX(one) AS max_one FROM A",
         parents=[B],
     )
     session.add(D)
@@ -1296,7 +1296,7 @@ async def test_get_query_for_sql_not_metric(
 
     B = Node(
         name="B",
-        expression="SELECT one FROM A",
+        query="SELECT one FROM A",
         parents=[A],
     )
     session.add(B)
@@ -1327,7 +1327,7 @@ async def test_get_query_for_sql_no_databases(
     B = Node(
         name="B",
         type=NodeType.METRIC,
-        expression="SELECT COUNT(*) AS cnt FROM A",
+        query="SELECT COUNT(*) AS cnt FROM A",
         parents=[A],
     )
     session.add(B)
@@ -1371,7 +1371,7 @@ async def test_get_query_for_sql_alias(mocker: MockerFixture, session: Session) 
     B = Node(
         name="B",
         type=NodeType.METRIC,
-        expression="SELECT COUNT(*) AS cnt FROM A",
+        query="SELECT COUNT(*) AS cnt FROM A",
         parents=[A],
     )
     session.add(B)
@@ -1426,7 +1426,7 @@ async def test_get_query_for_sql_where_groupby(
     num_comments = Node(
         name="core.num_comments",
         type=NodeType.METRIC,
-        expression="SELECT COUNT(*) FROM core.comments",
+        query="SELECT COUNT(*) FROM core.comments",
         parents=[comments],
     )
     session.add(num_comments)
@@ -1486,7 +1486,7 @@ async def test_get_query_for_sql_date_trunc(
     num_comments = Node(
         name="core.num_comments",
         type=NodeType.METRIC,
-        expression="SELECT COUNT(*) FROM core.comments",
+        query="SELECT COUNT(*) FROM core.comments",
         parents=[comments],
     )
     session.add(num_comments)
@@ -1548,7 +1548,7 @@ async def test_get_query_for_sql_invalid_column(
     num_comments = Node(
         name="core.num_comments",
         type=NodeType.METRIC,
-        expression="SELECT COUNT(*) FROM core.comments",
+        query="SELECT COUNT(*) FROM core.comments",
         parents=[comments],
     )
     session.add(num_comments)

--- a/tests/sql/dag_test.py
+++ b/tests/sql/dag_test.py
@@ -96,7 +96,7 @@ def test_get_computable_databases_heterogeneous_columns() -> None:
 
     child_1 = Node(
         name="core.B",
-        expression="SELECT COUNT(core.A.user_id) FROM core.A",
+        query="SELECT COUNT(core.A.user_id) FROM core.A",
         parents=[parent],
     )
 
@@ -106,7 +106,7 @@ def test_get_computable_databases_heterogeneous_columns() -> None:
 
     child_2 = Node(
         name="core.C",
-        expression="SELECT COUNT(user_id) FROM core.A",
+        query="SELECT COUNT(user_id) FROM core.A",
         parents=[parent],
     )
 
@@ -251,7 +251,7 @@ def test_get_dimensions() -> None:
 
     child = Node(
         name="C",
-        expression="SELECT COUNT(*) FROM A",
+        query="SELECT COUNT(*) FROM A",
         parents=[parent],
     )
 

--- a/tests/sql/inference_test.py
+++ b/tests/sql/inference_test.py
@@ -18,11 +18,11 @@ from datajunction.sql.parse import find_nodes_by_key
 from datajunction.typing import ColumnType, Expression
 
 
-def get_expression(sql: str) -> Expression:
+def get_expression(query: str) -> Expression:
     """
     Return the first expression of the first projection.
     """
-    tree = parse_sql(sql, dialect="ansi")
+    tree = parse_sql(query, dialect="ansi")
     projection = next(find_nodes_by_key(tree, "projection"))
     expression = projection[0]
 

--- a/tests/sql/sqlalchemy/dialect_test.py
+++ b/tests/sql/sqlalchemy/dialect_test.py
@@ -118,7 +118,7 @@ def test_get_columns(mocker: MockerFixture, requests_mock: Mocker) -> None:
                 "description": "Number of comments",
                 "created_at": "2022-04-10T20:23:01.961078",
                 "updated_at": "2022-04-10T20:23:01.961083",
-                "expression": "SELECT COUNT(*) FROM core.comments",
+                "query": "SELECT COUNT(*) FROM core.comments",
                 "dimensions": [
                     "core.comments.id",
                     "core.comments.user_id",
@@ -140,7 +140,7 @@ def test_get_columns(mocker: MockerFixture, requests_mock: Mocker) -> None:
                 "created_at": "2022-04-10T20:22:58.345198",
                 "updated_at": "2022-04-10T20:22:58.345201",
                 "type": "source",
-                "expression": None,
+                "query": None,
                 "columns": [
                     {
                         "name": "id",
@@ -175,7 +175,7 @@ def test_get_columns(mocker: MockerFixture, requests_mock: Mocker) -> None:
                 "created_at": "2022-04-10T20:23:01.333020",
                 "updated_at": "2022-04-10T20:23:01.333024",
                 "type": "dimension",
-                "expression": None,
+                "query": None,
                 "columns": [
                     {
                         "name": "id",
@@ -214,7 +214,7 @@ def test_get_columns(mocker: MockerFixture, requests_mock: Mocker) -> None:
                 "created_at": "2022-04-10T20:23:01.961078",
                 "updated_at": "2022-04-10T20:23:01.961083",
                 "type": "metric",
-                "expression": "SELECT COUNT(*) FROM core.comments",
+                "query": "SELECT COUNT(*) FROM core.comments",
                 "columns": [
                     {
                         "name": "_col0",

--- a/tests/sql/transpile_test.py
+++ b/tests/sql/transpile_test.py
@@ -46,7 +46,7 @@ def test_get_select_for_node_materialized(mocker: MockerFixture) -> None:
                 columns=[Column(name="cnt", type=ColumnType.INT)],
             ),
         ],
-        expression="SELECT COUNT(*) AS cnt FROM A",
+        query="SELECT COUNT(*) AS cnt FROM A",
         parents=[parent],
     )
 
@@ -96,7 +96,7 @@ def test_get_select_for_node_not_materialized(mocker: MockerFixture) -> None:
 
     child = Node(
         name="B",
-        expression="SELECT COUNT(*) AS cnt FROM A",
+        query="SELECT COUNT(*) AS cnt FROM A",
         parents=[parent],
     )
 
@@ -110,7 +110,7 @@ FROM "A_fast") AS "A"'''
     )
 
     # unnamed expression
-    child.expression = "SELECT COUNT(*) FROM A"
+    child.query = "SELECT COUNT(*) FROM A"
 
     assert (
         query_to_string(get_select_for_node(child, database))
@@ -159,7 +159,7 @@ def test_get_select_for_node_choose_slow(mocker: MockerFixture) -> None:
 
     child = Node(
         name="B",
-        expression="SELECT COUNT(*) AS cnt FROM A WHERE two = 'test'",
+        query="SELECT COUNT(*) AS cnt FROM A WHERE two = 'test'",
         parents=[parent],
     )
 
@@ -205,7 +205,7 @@ def test_get_select_for_node_projection(mocker: MockerFixture) -> None:
 
     child = Node(
         name="B",
-        expression="SELECT one, MAX(two), 3, 4.0, 'five' FROM A",
+        query="SELECT one, MAX(two), 3, 4.0, 'five' FROM A",
         parents=[parent],
     )
 
@@ -250,7 +250,7 @@ def test_get_select_for_node_where(mocker: MockerFixture) -> None:
 
     child = Node(
         name="B",
-        expression="SELECT one, MAX(two), 3, 4.0, 'five' FROM A WHERE one > 10",
+        query="SELECT one, MAX(two), 3, 4.0, 'five' FROM A WHERE one > 10",
         parents=[parent],
     )
 
@@ -296,7 +296,7 @@ def test_get_select_for_node_groupby(mocker: MockerFixture) -> None:
 
     child = Node(
         name="B",
-        expression="SELECT one, MAX(two) FROM A GROUP BY one",
+        query="SELECT one, MAX(two) FROM A GROUP BY one",
         parents=[parent],
     )
 
@@ -341,7 +341,7 @@ def test_get_select_for_node_limit(mocker: MockerFixture) -> None:
 
     child = Node(
         name="B",
-        expression="SELECT one, MAX(two) FROM A LIMIT 10",
+        query="SELECT one, MAX(two) FROM A LIMIT 10",
         parents=[parent],
     )
 
@@ -398,7 +398,7 @@ def test_get_value() -> None:
 
 def test_get_select_for_node_with_join(mocker: MockerFixture) -> None:
     """
-    Test ``get_select_for_node`` when the node expression has a join.
+    Test ``get_select_for_node`` when the node query has a join.
     """
     database = Database(id=1, name="db", URI="sqlite://")
 
@@ -445,7 +445,7 @@ def test_get_select_for_node_with_join(mocker: MockerFixture) -> None:
 
     child = Node(
         name="B",
-        expression="SELECT COUNT(*) FROM A JOIN B ON A.two = B.two WHERE B.three > 1",
+        query="SELECT COUNT(*) FROM A JOIN B ON A.two = B.two WHERE B.three > 1",
         parents=[parent_1, parent_2],
     )
 


### PR DESCRIPTION
Renamed the attribute to "query", since it's more appropriate.