### PR TITLE
add-database command

### DIFF
--- a/src/datajunction/cli/add_database.py
+++ b/src/datajunction/cli/add_database.py
@@ -1,0 +1,45 @@
+"""
+Add a database to an existing repository
+"""
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from datajunction.errors import DJError, DJException, ErrorCode
+from datajunction.models.database import Database
+
+_logger = logging.getLogger(__name__)
+
+def create_databases_dir(repository: Path):
+    """
+    Creates a databases directory in the repository if one doesn't already exist
+    """
+    database_dir_path = repository / Path("databases")
+    database_dir_path.mkdir(exist_ok=True)
+
+async def run(repository: Path, database: str, uri: str, description: Optional[str] = None, read_only: Optional[bool] = None, cost: Optional[float] = None) -> None:
+    """
+    Add a database.
+    """
+    create_databases_dir(repository)
+    db_config_path = repository / Path(f"databases/{database}.yaml")
+    if Path(db_config_path).exists():
+        raise DJException(message=f"Database configuration already exists", errors=[DJError(message=f"{db_config_path} already exists", code=ErrorCode.ALREADY_EXISTS)])
+
+    db_kwargs = {
+      "database": database,
+      "URI": uri,
+    }
+    if description:
+      db_kwargs["description"] = description
+    if read_only:
+      db_kwargs["read_only"] = read_only
+    if cost:
+      db_kwargs["cost"] = cost
+
+    db = Database(**db_kwargs)
+    with db_config_path.open("w", encoding="utf-8") as output:
+        yaml.safe_dump(db.to_yaml(), output, sort_keys=False)

--- a/src/datajunction/console.py
+++ b/src/datajunction/console.py
@@ -3,9 +3,17 @@ DataJunction (DJ) is a metric repository.
 
 Usage:
     dj compile [REPOSITORY] [-f] [--loglevel=INFO] [--reload]
+    dj add-database DATABASE [REPOSITORY] --uri=URI [-f --loglevel=INFO --description=<str> --read-only=<bool> --cost=COST]
 
 Actions:
     compile                 Compile repository
+    add-database            Add a database to an existing repository
+
+Arguments:
+    REPOSITORY              Path to a DJ repository
+    DATABASE                Name of a database
+    URI                     URI to a database
+    COST                    The relative cost as compared to other databases
 
 Options:
     -f, --force             Force indexing.    [default: false]
@@ -24,6 +32,7 @@ from docopt import docopt
 
 from datajunction import __version__
 from datajunction.cli import compile as compile_
+from datajunction.cli import add_database as add_database_
 from datajunction.errors import DJException
 from datajunction.utils import get_settings, setup_logging
 
@@ -45,7 +54,7 @@ async def main() -> None:
         repository = Path(arguments["REPOSITORY"])
 
     try:
-        if arguments["compile"]:
+        if arguments.get("compile"):
             try:
                 await compile_.run(
                     repository,
@@ -54,6 +63,19 @@ async def main() -> None:
                 )
             except DJException as exc:
                 _logger.error(exc)
+        elif arguments.get("add-database"):
+            try:
+                await add_database_.run(
+                    repository,
+                    database=arguments["DATABASE"],
+                    uri=arguments["--uri"],
+                    description=arguments["--description"],
+                    read_only=arguments["--read-only"],
+                    cost=arguments["--cost"]
+                )
+            except DJException as exc:
+                _logger.error(exc)
+
     except asyncio.CancelledError:
         _logger.info("Canceled")
 

--- a/src/datajunction/errors.py
+++ b/src/datajunction/errors.py
@@ -16,6 +16,7 @@ class ErrorCode(int, Enum):
     # generic errors
     UNKWNON_ERROR = 0
     NOT_IMPLEMENTED_ERROR = 1
+    ALREADY_EXISTS = 2
 
     # metric API
     INVALID_FILTER_PATTERN = 100

--- a/src/datajunction/models/node.py
+++ b/src/datajunction/models/node.py
@@ -167,7 +167,7 @@ class Node(SQLModel, table=True):  # type: ignore
         Extra validation for node data.
         """
         if self.type == NodeType.SOURCE:
-            if self.expression:
+            if self.query:
                 raise Exception(
                     f"Node {self.name} of type source should not have an expression",
                 )

--- a/tests/cli/add_database_test.py
+++ b/tests/cli/add_database_test.py
@@ -1,0 +1,79 @@
+
+
+from pathlib import Path
+import tempfile
+
+import pytest
+import yaml
+
+from datajunction.cli import add_database
+from datajunction.errors import DJException
+
+@pytest.mark.asyncio
+async def test_add_database_minimum_requirements() -> None:
+    """
+    Test adding a database with the minimum required arguments
+    """
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        await add_database.run(
+            Path(tmpdirname),
+            database="testdb",
+            uri="testdb://test",
+        )
+        with open(Path(tmpdirname) / Path("databases/testdb.yaml"), "r") as f:
+            assert yaml.safe_load(f) == {
+                "URI": "testdb://test",
+                "async_": False,
+                "cost": 1.0,  # default
+                "description": "",  # default
+                "read-only": True  # default
+            }
+
+@pytest.mark.asyncio
+async def test_add_database() -> None:
+    """
+    Test adding a database using required and optional arguments
+    """
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        await add_database.run(
+            Path(tmpdirname),
+            database="testdb",
+            uri="testdb://test",
+            description="This is a description",
+            read_only=True,
+            cost=11.0
+        )
+        with open(Path(tmpdirname) / Path("databases/testdb.yaml"), "r") as f:
+            assert yaml.safe_load(f) == {
+                "URI": "testdb://test",
+                "async_": False,
+                "cost": 11.0,
+                "description": "This is a description",
+                "read-only": True
+            }
+
+@pytest.mark.asyncio
+async def test_add_database_raise_config_already_exists() -> None:
+    """
+    Test raising an exception when adding a database that already exists
+    """
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        await add_database.run(
+            Path(tmpdirname),
+            database="testdb",
+            uri="testdb://test",
+            description="This is a description",
+            read_only=True,
+            cost=11.0
+        )
+        with pytest.raises(DJException) as exc_info:
+            await add_database.run(
+                Path(tmpdirname),
+                database="testdb",
+                uri="testdb://test",
+                description="This is a description",
+                read_only=True,
+                cost=11.0
+            )
+        
+        assert "Database configuration already exists" in str(exc_info.value)

--- a/tests/models/node_test.py
+++ b/tests/models/node_test.py
@@ -38,7 +38,7 @@ def test_extra_validation() -> None:
         node.extra_validation()
     assert str(excinfo.value) == "Node A of type source needs at least one table"
 
-    node = Node(name="A", type=NodeType.SOURCE, expression="SELECT * FROM B")
+    node = Node(name="A", type=NodeType.SOURCE, query="SELECT * FROM B")
     with pytest.raises(Exception) as excinfo:
         node.extra_validation()
     assert str(excinfo.value) == "Node A of type source should not have an expression"


### PR DESCRIPTION
This is an attempt to solve issue #98, adding an `add-database` command.
```
dj add-database DATABASE [REPOSITORY] --uri=URI [-f --loglevel=INFO --description=<str> --read-only=<bool> --cost=COST]
```