### PR TITLE
Add error handling to read metric route `*/metrics/N/` (Closes #170)

### DIFF
--- a/src/datajunction/api/metrics.py
+++ b/src/datajunction/api/metrics.py
@@ -63,6 +63,16 @@ def read_metric(node_id: int, *, session: Session = Depends(get_session)) -> Met
     Return a metric by ID.
     """
     node = session.get(Node, node_id)
+    if not node:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND,
+            detail="Metric node not found",
+        )
+    if node.type != NodeType.METRIC:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail="Not a metric node",
+        )
     return Metric(**node.dict(), dimensions=get_dimensions(node))
 
 

--- a/tests/api/metrics_test.py
+++ b/tests/api/metrics_test.py
@@ -84,6 +84,26 @@ def test_read_metric(session: Session, client: TestClient) -> None:
     assert data["dimensions"] == ["parent.ds", "parent.foo", "parent.user_id"]
 
 
+def test_read_metrics_errors(session: Session, client: TestClient) -> None:
+    """
+    Test errors on ``GET /metrics/{node_id}/``.
+    """
+    database = Database(name="test", URI="sqlite://")
+    node = Node(name="a-metric", query="SELECT 1 AS col")
+    session.add(database)
+    session.add(node)
+    session.execute("CREATE TABLE my_table (one TEXT)")
+    session.commit()
+
+    response = client.get("/metrics/2")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Metric node not found"}
+
+    response = client.get("/metrics/1")
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Not a metric node"}
+
+
 def test_read_metrics_data(
     mocker: MockerFixture,
     session: Session,


### PR DESCRIPTION
This adds error handling that returns a "metric not found" or "not a metric" error when calling the `*/metrics/N/` route, the same way the `*/metrics/N/data` route does.

```bash
$ curl http://localhost:8000/metrics/5/
{"detail":"Metric node not found"}
```
```bash
$ curl http://localhost:8000/metrics/3/
{"detail":"Not a metric node"}
```
This closes #170 